### PR TITLE
feat: Add CMS image upload for project cards with Supabase persistence

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -8,6 +8,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { submitSiteVisit } from '@/lib/storage';
+import { getProjectImagesFromDB } from '@/lib/contentStorage';
 import { useToast } from '@/components/ui/use-toast';
 import EMICalculatorSection from '@/components/EMICalculatorSection';
 import PresetPlotCards from '@/components/PresetPlotCards';
@@ -16,6 +17,7 @@ import { useWhatsApp } from '@/lib/useWhatsApp';
 const projects = [
   {
     id: 'khatu-shyam-enclave',
+    slug: 'khatu-shyam-enclave',
     nameEn: 'Shri Khatu Shyam Enclave',
     logo: '/images/projects/khatu_shyam_enclave.png',
     location: 'Near Khatu Shyam Temple, Rajasthan',
@@ -29,6 +31,7 @@ const projects = [
   },
   {
     id: 'shree-kunj-bihari-enclave',
+    slug: 'shree-kunj-bihari',
     nameEn: 'Shree Kunj Bihari Enclave',
     logo: '/images/projects/shree_kunj_bihari_enclave.png',
     location: 'Vrindavan, UP',
@@ -42,6 +45,7 @@ const projects = [
   },
   {
     id: 'gokul-vatika',
+    slug: 'gokul-vatika',
     nameEn: 'Gokul Vatika',
     logo: '/images/projects/gokul_vatika.png',
     location: 'Mathura-Vrindavan Road',
@@ -54,6 +58,7 @@ const projects = [
   },
   {
     id: 'semri-vatika',
+    slug: 'maa-simri-vatika',
     nameEn: 'Maa Semri Vatika',
     logo: '/images/projects/semri_vatika.png',
     location: 'Semri, Mathura',
@@ -66,6 +71,7 @@ const projects = [
   },
   {
     id: 'jagannath-dham',
+    slug: 'jagannath-dham',
     nameEn: 'Jagannath Dham',
     logo: '/images/projects/jaganath_dham.png',
     location: 'Vrindavan Highway',
@@ -78,6 +84,7 @@ const projects = [
   },
   {
     id: 'brij-vatika',
+    slug: 'brij-vatika',
     nameEn: 'Brij Vatika (E Block)',
     logo: '/images/projects/brij_vatika.png',
     location: 'Braj Bhoomi, Vrindavan',
@@ -125,6 +132,11 @@ const HomePage = ({ onBookSiteVisit }) => {
   const { getWhatsAppLink } = useWhatsApp();
   const [currentSlide, setCurrentSlide] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [dbImages, setDbImages] = useState({});
+
+  useEffect(() => {
+    getProjectImagesFromDB().then(imgs => setDbImages(imgs));
+  }, []);
 
   useEffect(() => {
     const timer = setInterval(() => setCurrentSlide(prev => (prev + 1) % slides.length), 5000);
@@ -254,7 +266,7 @@ const HomePage = ({ onBookSiteVisit }) => {
                 <div className="bg-gradient-to-br from-[#0F3A5F] to-[#1a5a8f] p-6 flex items-center justify-center min-h-[200px] relative overflow-hidden">
                   <div className="absolute inset-0 bg-[#D4AF37]/5 opacity-0 group-hover:opacity-100 transition-opacity" />
                   <img
-                    src={project.logo}
+                    src={dbImages[project.slug] || project.logo}
                     alt={project.nameEn}
                     className="max-w-full max-h-[175px] object-contain group-hover:scale-105 transition-transform duration-300 relative z-10"
                   />


### PR DESCRIPTION
## Summary
Adds **ProjectImageManager** component to CMS dashboard (`/crm/admin/cms`) allowing admins to upload custom hero images for all 6 projects. Images are stored in Supabase Storage and URLs are persisted to the `project_content` table so all visitors see the changes immediately.

## Changes Made
### 1. **CMS Image Upload Component** ([abfb850](https://github.com/fadoomotivation-pixel/fanbe-hostinger/commit/abfb850bd9458316a146da5e80f49740390b69a9))
- Added `ProjectImageManager` to `/crm/admin/cms`
- Displays all 6 project cards in grid with current hero images
- Upload button per card → uploads to Supabase `project-images` bucket
- Cross-tab sync via contentStorage events

### 2. **Database Persistence** ([0ef5735](https://github.com/fadoomotivation-pixel/fanbe-hostinger/commit/0ef5735f08bbf26586121d0ffb86f76036b377bb))
- After upload to Supabase Storage, URLs are upserted into `project_content` table
- Fixes issue where only admin (localStorage) saw changes
- All visitors now fetch from DB → see latest images immediately

### 3. **Homepage Integration + Slug Fixes** ([3d2df34](https://github.com/fadoomotivation-pixel/fanbe-hostinger/commit/3d2df34b8ffc9fd99c39d7dc4d7e0102b56f0cb2))
- HomePage fetches images from Supabase DB on mount
- Corrected slug mismatches:
  - `shree-kunj-bihari-enclave` → `shree-kunj-bihari`
  - `semri-vatika` → `maa-simri-vatika`
- Falls back to logo if no DB image exists

## Testing Checklist
- [x] CMS upload interface works
- [x] Images persist to Supabase Storage
- [x] URLs saved to `project_content` table
- [x] HomePage displays DB images for all visitors
- [x] Slug matching works correctly

## Deploy Instructions
After merge, run from Git Bash:
```bash
git pull origin main
git push hostinger main
```

---
**Branch:** `claude/admin-cms-image-upload-3Xo2F`  
**Target:** `main`  
**Commits:** 3 (all by Claude + you)