### PR TITLE
Fix mobile lead status flow and connect booking data to analytics

### DIFF
--- a/src/crm/hooks/useCRMData.js
+++ b/src/crm/hooks/useCRMData.js
@@ -208,6 +208,11 @@ export const useCRMData = () => {
         activityLog:      [],
         project:          row.project            || '',
         followUpDate:     row.next_followup_date || null,
+        tokenAmount:      row.token_amount       || 0,
+        bookingAmount:    row.booking_amount     || 0,
+        partialPayment:   row.partial_payment    || 0,
+        paymentMode:      row.payment_mode       || 'Cash',
+        unitNumber:       row.unit_number        || '',
         isVIP:            row.is_vip             || false,
       }));
 
@@ -292,6 +297,11 @@ export const useCRMData = () => {
       if (updates.assignedToName   !== undefined) mapped.assigned_to_name   = updates.assignedToName;
       if (updates.project          !== undefined) mapped.project            = updates.project;
       if (updates.followUpDate     !== undefined) mapped.next_followup_date = updates.followUpDate;
+      if (updates.tokenAmount      !== undefined) mapped.token_amount       = updates.tokenAmount || 0;
+      if (updates.bookingAmount    !== undefined) mapped.booking_amount     = updates.bookingAmount || 0;
+      if (updates.partialPayment   !== undefined) mapped.partial_payment    = updates.partialPayment || 0;
+      if (updates.paymentMode      !== undefined) mapped.payment_mode       = updates.paymentMode || 'Cash';
+      if (updates.unitNumber       !== undefined) mapped.unit_number        = updates.unitNumber || '';
       if (updates.isVIP            !== undefined) mapped.is_vip             = updates.isVIP;
       mapped.updated_at = new Date().toISOString();
 

--- a/src/crm/pages/MobileLeadDetails.jsx
+++ b/src/crm/pages/MobileLeadDetails.jsx
@@ -10,6 +10,15 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/components/ui/use-toast';
 
+const normalizeLeadStatus = (status) => {
+  if (!status) return 'Open';
+  const cleaned = String(status).trim().toLowerCase().replace(/[\s_-]+/g, '');
+  if (cleaned === 'followup') return 'FollowUp';
+  if (cleaned === 'booked') return 'Booked';
+  if (cleaned === 'lost') return 'Lost';
+  return 'Open';
+};
+
 const parseNotes = (notes) => {
   if (!notes) return [];
   if (Array.isArray(notes)) {
@@ -43,16 +52,17 @@ const statusConfig = {
 const MobileLeadDetails = () => {
   const { leadId } = useParams();
   const navigate = useNavigate();
-  const { leads, updateLead, addLeadNote } = useCRMData();
+  const { leads, updateLead, addLeadNote, addBookingLog } = useCRMData();
   const { toast } = useToast();
 
   const lead = leads.find(l => l.id === leadId);
   const [isUpdateOpen, setIsUpdateOpen] = useState(false);
   const [noteText, setNoteText] = useState('');
   const [statusForm, setStatusForm] = useState({
-    status:         lead?.status          || 'Open',
+    status:         normalizeLeadStatus(lead?.status),
     followUpDate:   lead?.followUpDate?.split('T')[0] || '',
     followUpTime:   lead?.followUpTime    || '',
+    bookingAmount:  lead?.bookingAmount   || lead?.partialPayment || '',
     tokenAmount:    lead?.tokenAmount     || '',
     partialPayment: lead?.partialPayment  || '',
     paymentMode:    lead?.paymentMode     || 'Cash',
@@ -62,7 +72,8 @@ const MobileLeadDetails = () => {
 
   if (!lead) return <div className="p-8 text-center text-gray-500">Lead not found</div>;
 
-  const sc = statusConfig[lead.status] || statusConfig.Open;
+  const currentLeadStatus = normalizeLeadStatus(lead.status);
+  const sc = statusConfig[currentLeadStatus] || statusConfig.Open;
   const parsedNotes = parseNotes(lead.notes);
 
   const handleAddNote = () => {
@@ -72,23 +83,51 @@ const MobileLeadDetails = () => {
     toast({ title: 'Note Added', description: 'Note saved successfully.' });
   };
 
-  const handleUpdate = () => {
+  const handleUpdate = async () => {
     const isFollowUp = statusForm.status === 'FollowUp';
     const isBooked   = statusForm.status === 'Booked';
-    updateLead(lead.id, {
-      status:        statusForm.status,
-      followUpDate:  isFollowUp ? statusForm.followUpDate : '',
-      followUpTime:  isFollowUp ? statusForm.followUpTime : '',
-      ...(isBooked && {
-        tokenAmount:    statusForm.tokenAmount,
-        partialPayment: statusForm.partialPayment,
-        paymentMode:    statusForm.paymentMode,
-        unitNumber:     statusForm.unitNumber,
-      }),
-    });
-    if (statusForm.notes) addLeadNote(lead.id, statusForm.notes, 'Sales (Mobile)');
-    toast({ title: 'Success', description: 'Status updated.' });
-    setIsUpdateOpen(false);
+
+    if (isFollowUp && !statusForm.followUpDate) {
+      toast({ title: 'Follow-up date missing', description: 'Please select follow-up date first.', variant: 'destructive' });
+      return;
+    }
+
+    try {
+      await updateLead(lead.id, {
+        status:        statusForm.status,
+        followUpDate:  isFollowUp ? statusForm.followUpDate : '',
+        followUpTime:  isFollowUp ? statusForm.followUpTime : '',
+        ...(isBooked && {
+          bookingAmount:  statusForm.bookingAmount,
+          tokenAmount:    statusForm.tokenAmount,
+          partialPayment: statusForm.partialPayment,
+          paymentMode:    statusForm.paymentMode,
+          unitNumber:     statusForm.unitNumber,
+        }),
+      });
+
+      if (isBooked) {
+        const amount = Number(statusForm.bookingAmount || statusForm.partialPayment || statusForm.tokenAmount || 0);
+        await addBookingLog({
+          employeeId: lead.assignedTo || lead.assigned_to || null,
+          leadId: lead.id,
+          leadName: lead.name,
+          projectName: lead.project,
+          unitNumber: statusForm.unitNumber,
+          bookingAmount: amount,
+          amount,
+          paymentMode: statusForm.paymentMode,
+          notes: `Token: ₹${statusForm.tokenAmount || 0}${statusForm.notes ? ` | ${statusForm.notes}` : ''}`,
+        });
+      }
+
+      if (statusForm.notes) addLeadNote(lead.id, statusForm.notes, 'Sales (Mobile)');
+      toast({ title: 'Success', description: 'Status updated.' });
+      setIsUpdateOpen(false);
+    } catch (error) {
+      console.error('[MobileLeadDetails] Failed to update status:', error);
+      toast({ title: 'Update failed', description: 'Please retry. If issue continues, contact admin.', variant: 'destructive' });
+    }
   };
 
   return (
@@ -247,9 +286,10 @@ const MobileLeadDetails = () => {
           className={`w-full h-12 text-base font-bold ${sc.bg} ${sc.hover} text-white`}
           onClick={() => {
             setStatusForm({
-              status:         lead.status,
+              status:         normalizeLeadStatus(lead.status),
               followUpDate:   lead?.followUpDate?.split('T')[0] || '',
               followUpTime:   lead?.followUpTime    || '',
+              bookingAmount:  lead?.bookingAmount   || lead?.partialPayment || '',
               tokenAmount:    lead?.tokenAmount     || '',
               partialPayment: lead?.partialPayment  || '',
               paymentMode:    lead?.paymentMode     || 'Cash',
@@ -320,6 +360,16 @@ const MobileLeadDetails = () => {
               <div className="space-y-3 bg-emerald-50 rounded-xl p-3 border border-emerald-200">
                 <p className="text-xs font-semibold text-emerald-700 uppercase tracking-wide">Booking Details</p>
                 <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1">
+                    <label className="text-xs font-medium text-slate-700">Booking Amount (₹)</label>
+                    <Input
+                      type="number"
+                      placeholder="e.g. 850000"
+                      value={statusForm.bookingAmount}
+                      onChange={e => setStatusForm({ ...statusForm, bookingAmount: e.target.value })}
+                      className="h-9 border-slate-200 text-sm"
+                    />
+                  </div>
                   <div className="space-y-1">
                     <label className="text-xs font-medium text-slate-700">Token Amount (₹)</label>
                     <Input

--- a/src/crm/pages/RevenueAnalytics.jsx
+++ b/src/crm/pages/RevenueAnalytics.jsx
@@ -9,25 +9,25 @@ import {
 import { Download, Calendar, DollarSign, TrendingUp } from 'lucide-react';
 
 const RevenueAnalytics = () => {
-  const { customers, projects } = useCRMData();
+  const { bookings, leads } = useCRMData();
   const [dateRange, setDateRange] = useState('year');
 
   // ─── Calculate Real Stats ────────────────────────────────────────────────────────────────────────────────
-  const totalRevenue = customers.reduce((acc, c) => acc + (c.bookingAmount || 0), 0);
-  const bookingCount = customers.filter(c => c.status === 'Booked').length;
+  const totalRevenue = bookings.reduce((acc, b) => acc + (b.amount || 0), 0);
+  const bookingCount = bookings.length;
   const avgRevenuePerBooking = bookingCount > 0 ? Math.round(totalRevenue / bookingCount) : 0;
   const projectedMonthlyRevenue = totalRevenue > 0 ? Math.round(totalRevenue / 12) : 0; // Rough yearly projection / 12
 
   // ─── Monthly Revenue Trend (from customers' createdAt or updatedAt) ──────────────────────────────────────
   const monthlyDataMap = {};
-  customers.forEach(c => {
-    if (!c.bookingAmount || c.bookingAmount <= 0) return;
-    const date = new Date(c.updatedAt || c.createdAt || Date.now());
+  bookings.forEach(b => {
+    if (!b.amount || b.amount <= 0) return;
+    const date = new Date(b.bookingDate || b.timestamp || Date.now());
     const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
     if (!monthlyDataMap[monthKey]) {
       monthlyDataMap[monthKey] = { name: monthKey, revenue: 0, bookings: 0 };
     }
-    monthlyDataMap[monthKey].revenue += c.bookingAmount;
+    monthlyDataMap[monthKey].revenue += b.amount;
     monthlyDataMap[monthKey].bookings += 1;
   });
   const monthlyData = Object.values(monthlyDataMap).sort((a, b) => a.name.localeCompare(b.name)).slice(-6); // Last 6 months
@@ -39,18 +39,19 @@ const RevenueAnalytics = () => {
 
   // ─── Revenue by Project ───────────────────────────────────────────────────────────────────────────────────
   const projectRevenueMap = {};
-  customers.forEach(c => {
-    if (!c.bookingAmount || c.bookingAmount <= 0) return;
-    const projId = c.projectId || 'Unassigned';
+  bookings.forEach(b => {
+    if (!b.amount || b.amount <= 0) return;
+    const lead = leads.find(l => l.id === b.leadId);
+    const projId = lead?.project || b.projectName || 'Unassigned';
     if (!projectRevenueMap[projId]) {
       projectRevenueMap[projId] = 0;
     }
-    projectRevenueMap[projId] += c.bookingAmount;
+    projectRevenueMap[projId] += b.amount;
   });
-  const projectRevenueData = Object.entries(projectRevenueMap).map(([projId, value]) => {
-    const proj = projects.find(p => p.id === projId);
-    return { name: proj?.name || projId, value };
-  }).sort((a, b) => b.value - a.value).slice(0, 5); // Top 5
+  const projectRevenueData = Object.entries(projectRevenueMap).map(([projName, value]) => ({
+    name: projName,
+    value,
+  })).sort((a, b) => b.value - a.value).slice(0, 5); // Top 5
 
   // ─── Render ───────────────────────────────────────────────────────────────────────────────────────────────
   return (


### PR DESCRIPTION
### Motivation
- Mobile "Update Status" was breaking when leads had inconsistent status strings and booking data wasn't being captured, causing missing booking events in analytics.
- Employee intelligence and revenue reports relied on placeholder/customer fields instead of real booking records, producing incorrect revenue metrics.

### Description
- Normalized lead status values in the mobile UI (`normalizeLeadStatus`) and added validation + error toast handling to prevent failed updates on mobile. (changes in `src/crm/pages/MobileLeadDetails.jsx`)
- Extended the mobile booking workflow to capture `bookingAmount`, `tokenAmount`, `partialPayment`, `paymentMode`, and `unitNumber`, and create a booking log via `addBookingLog` when a lead is set to `Booked`. (changes in `src/crm/pages/MobileLeadDetails.jsx`)
- Updated `useCRMData` mapping and `updateLead` to read and persist booking/token fields from Supabase (`token_amount`, `booking_amount`, `partial_payment`, `payment_mode`, `unit_number`). (changes in `src/crm/hooks/useCRMData.js`)
- Rewired `RevenueAnalytics` to compute revenue and trends from real `bookings` data (monthly trend and project revenue grouping) instead of the earlier `customers` placeholder. (changes in `src/crm/pages/RevenueAnalytics.jsx`)

### Testing
- Ran `npm run build` successfully and verified the production build completed without fatal errors. (succeeded)
- Launched the dev server (`npm run dev -- --host 0.0.0.0 --port 4173`) and captured a headless mobile viewport screenshot to validate the mobile UI. (succeeded)
- Committed the changes and created the PR titled: "Fix mobile lead status flow and connect booking data to analytics". (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b7965ed4832688cb718d30570ba9)