### PR TITLE
Fix stale Hostinger deployments — unique Vite build IDs, clean rebuild and /api/version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "build": "node scripts/build.mjs",
+    "preview": "vite preview",
+    "build:clean": "bash scripts/deploy-clean-rebuild.sh"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.4.0",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,6 +6,9 @@
   RewriteCond %{HTTPS} off
   RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
+  # API endpoint for build/version diagnostics
+  RewriteRule ^api/version/?$ api/version.php [L,QSA]
+
   # Handle SPA routing — send all non-file/dir requests to index.html
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
@@ -26,6 +29,18 @@
     Header set Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
     Header set Pragma "no-cache"
     Header set Expires "0"
+  </FilesMatch>
+
+
+  # Version metadata + API responses should never be cached
+  <FilesMatch "^(index\.html|version\.json)$">
+    Header set Cache-Control "no-store, no-cache, must-revalidate, max-age=0, s-maxage=0"
+    Header set Pragma "no-cache"
+    Header set Expires "0"
+  </FilesMatch>
+
+  <FilesMatch "^version\.php$">
+    Header set Cache-Control "no-store, no-cache, must-revalidate, max-age=0, s-maxage=0"
   </FilesMatch>
 
   # Cache hashed JS/CSS assets aggressively — safe because Vite changes filename on every build

--- a/public/api/version.php
+++ b/public/api/version.php
@@ -1,0 +1,22 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0, s-maxage=0');
+header('Pragma: no-cache');
+header('Expires: 0');
+
+$versionFile = dirname(__DIR__) . '/version.json';
+$version = [];
+
+if (file_exists($versionFile)) {
+    $json = file_get_contents($versionFile);
+    $version = json_decode($json, true);
+}
+
+if (!is_array($version)) {
+    $version = [];
+}
+
+$version['serverTime'] = gmdate('c');
+$version['endpoint'] = '/api/version';
+
+echo json_encode($version, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);

--- a/public/version.json
+++ b/public/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.2.0",
-  "buildTime": "2026-03-05T16:00:00+05:30",
-  "cacheBreaker": "unified-mobile-desktop-ui-march-5-2026",
-  "changes": "Unified mobile and desktop lead details UI"
+  "buildId": "1772785117526-vc4z3z",
+  "buildTimestamp": "2026-03-06T08:18:37.525Z",
+  "gitCommit": "b741e66",
+  "gitBranch": "work"
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,38 @@
+import { execSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const now = new Date()
+const buildTimestamp = now.toISOString()
+const buildId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+const getCmdOutput = (cmd) => {
+  try {
+    return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+const versionInfo = {
+  buildId,
+  buildTimestamp,
+  gitCommit: getCmdOutput('git rev-parse --short HEAD'),
+  gitBranch: getCmdOutput('git rev-parse --abbrev-ref HEAD'),
+}
+
+const publicDir = resolve('public')
+mkdirSync(publicDir, { recursive: true })
+writeFileSync(resolve(publicDir, 'version.json'), `${JSON.stringify(versionInfo, null, 2)}\n`)
+
+console.log(`🔖 Build ID: ${buildId}`)
+execSync('npx vite build', {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    BUILD_ID: buildId,
+    BUILD_TIMESTAMP: buildTimestamp,
+    BUILD_COMMIT: versionInfo.gitCommit,
+    BUILD_BRANCH: versionInfo.gitBranch,
+  },
+})

--- a/scripts/deploy-clean-rebuild.sh
+++ b/scripts/deploy-clean-rebuild.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "🧹 Cleaning old build artifacts"
+rm -rf dist
+rm -rf node_modules/.vite 2>/dev/null || true
+
+echo "📦 Creating fresh Vite build"
+npm run build
+
+echo "🧾 Build version"
+cat dist/version.json
+
+echo "✅ Clean rebuild completed. Deploy dist/ to Hostinger public_html/."

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,22 +2,26 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-const timestamp = Date.now();
+const buildId = process.env.BUILD_ID || `${Date.now()}`;
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __BUILD_ID__: JSON.stringify(buildId),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
   },
   build: {
+    manifest: true,
     chunkSizeWarningLimit: 3000,
     rollupOptions: {
       output: {
-        entryFileNames: `assets/[name]-[hash]-${timestamp}.js`,
-        chunkFileNames: `assets/[name]-[hash]-${timestamp}.js`,
-        assetFileNames: `assets/[name]-[hash]-${timestamp}.[ext]`,
+        entryFileNames: `assets/[name]-[hash]-${buildId}.js`,
+        chunkFileNames: `assets/[name]-[hash]-${buildId}.js`,
+        assetFileNames: `assets/[name]-[hash]-${buildId}.[ext]`,
         manualChunks: {
           'vendor-react': ['react', 'react-dom', 'react-router-dom'],
           'vendor-supabase': ['@supabase/supabase-js'],


### PR DESCRIPTION
### Motivation
- Production was serving stale JS bundles because builds used a fixed timestamp and upstream caches (Hostinger/Cloudflare) kept serving old `index.html` that referenced old filenames. 
- The goal is to guarantee each Vite build produces uniquely named assets, make a simple clean-rebuild workflow, and expose build metadata so deployments can be validated remotely.

### Description
- Use an injected per-build `BUILD_ID` in `vite.config.js` for `entryFileNames`, `chunkFileNames` and `assetFileNames`, and enable `manifest: true` so assets are uniquely named per build; also expose `__BUILD_ID__` to the app. 
- Add `scripts/build.mjs` which generates a fresh `buildId` and `buildTimestamp`, writes `public/version.json` (buildId, timestamp, git commit, branch), and runs Vite with those env vars. 
- Update `package.json` to replace `build` with `node scripts/build.mjs` and add `build:clean` which calls the clean deploy script. 
- Add `scripts/deploy-clean-rebuild.sh` to remove old `dist` artifacts and force a fresh `npm run build`, printing the resulting `dist/version.json`. 
- Add `public/api/version.php` to return the generated build metadata with strict no-cache headers and update `public/.htaccess` to route `/api/version` to that endpoint and to prevent caching of `index.html` and `version.json` while preserving long-lived caching for hashed assets.

### Testing
- Ran `npm run build:clean` which completed successfully and produced a new `dist` with filenames suffixed by a new build ID (success). 
- Verified `dist/version.json` was generated and contains `buildId`, `buildTimestamp`, `gitCommit` and `gitBranch` (success). 
- Ran `php -l public/api/version.php` to validate PHP syntax for the new endpoint (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa8d6711248326849a359af2ebd2a6)