### PR TITLE
Add build metadata & version API; make Vite build deterministic; enhance lead update UI and call logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "build": "node scripts/build.mjs",
+    "preview": "vite preview",
+    "build:clean": "bash scripts/deploy-clean-rebuild.sh"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.4.0",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,6 +6,9 @@
   RewriteCond %{HTTPS} off
   RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
+  # API endpoint for build/version diagnostics
+  RewriteRule ^api/version/?$ api/version.php [L,QSA]
+
   # Handle SPA routing — send all non-file/dir requests to index.html
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
@@ -26,6 +29,18 @@
     Header set Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
     Header set Pragma "no-cache"
     Header set Expires "0"
+  </FilesMatch>
+
+
+  # Version metadata + API responses should never be cached
+  <FilesMatch "^(index\.html|version\.json)$">
+    Header set Cache-Control "no-store, no-cache, must-revalidate, max-age=0, s-maxage=0"
+    Header set Pragma "no-cache"
+    Header set Expires "0"
+  </FilesMatch>
+
+  <FilesMatch "^version\.php$">
+    Header set Cache-Control "no-store, no-cache, must-revalidate, max-age=0, s-maxage=0"
   </FilesMatch>
 
   # Cache hashed JS/CSS assets aggressively — safe because Vite changes filename on every build

--- a/public/api/version.php
+++ b/public/api/version.php
@@ -1,0 +1,22 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0, s-maxage=0');
+header('Pragma: no-cache');
+header('Expires: 0');
+
+$versionFile = dirname(__DIR__) . '/version.json';
+$version = [];
+
+if (file_exists($versionFile)) {
+    $json = file_get_contents($versionFile);
+    $version = json_decode($json, true);
+}
+
+if (!is_array($version)) {
+    $version = [];
+}
+
+$version['serverTime'] = gmdate('c');
+$version['endpoint'] = '/api/version';
+
+echo json_encode($version, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);

--- a/public/version.json
+++ b/public/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.2.0",
-  "buildTime": "2026-03-05T16:00:00+05:30",
-  "cacheBreaker": "unified-mobile-desktop-ui-march-5-2026",
-  "changes": "Unified mobile and desktop lead details UI"
+  "buildId": "1772785117526-vc4z3z",
+  "buildTimestamp": "2026-03-06T08:18:37.525Z",
+  "gitCommit": "b741e66",
+  "gitBranch": "work"
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,38 @@
+import { execSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const now = new Date()
+const buildTimestamp = now.toISOString()
+const buildId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+const getCmdOutput = (cmd) => {
+  try {
+    return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+const versionInfo = {
+  buildId,
+  buildTimestamp,
+  gitCommit: getCmdOutput('git rev-parse --short HEAD'),
+  gitBranch: getCmdOutput('git rev-parse --abbrev-ref HEAD'),
+}
+
+const publicDir = resolve('public')
+mkdirSync(publicDir, { recursive: true })
+writeFileSync(resolve(publicDir, 'version.json'), `${JSON.stringify(versionInfo, null, 2)}\n`)
+
+console.log(`🔖 Build ID: ${buildId}`)
+execSync('npx vite build', {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    BUILD_ID: buildId,
+    BUILD_TIMESTAMP: buildTimestamp,
+    BUILD_COMMIT: versionInfo.gitCommit,
+    BUILD_BRANCH: versionInfo.gitBranch,
+  },
+})

--- a/scripts/deploy-clean-rebuild.sh
+++ b/scripts/deploy-clean-rebuild.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "🧹 Cleaning old build artifacts"
+rm -rf dist
+rm -rf node_modules/.vite 2>/dev/null || true
+
+echo "📦 Creating fresh Vite build"
+npm run build
+
+echo "🧾 Build version"
+cat dist/version.json
+
+echo "✅ Clean rebuild completed. Deploy dist/ to Hostinger public_html/."

--- a/src/crm/pages/UpdateLeadStatus.jsx
+++ b/src/crm/pages/UpdateLeadStatus.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useCRMData } from '@/crm/hooks/useCRMData';
 import { useAuth } from '@/context/AuthContext';
 import { Button } from '@/components/ui/button';
@@ -11,13 +11,12 @@ import {
   ArrowLeft, Save, Flame, Wind, Snowflake, Phone, PhoneOff, PhoneMissed,
   Calendar, IndianRupee, MapPin, CheckCircle2, XCircle
 } from 'lucide-react';
-import { format } from 'date-fns';
+import { addDays, format } from 'date-fns';
 
 const UpdateLeadStatus = () => {
   const { leadId } = useParams();
   const navigate = useNavigate();
-  const location = useLocation();
-  const { leads, leadsLoading, updateLead, addLeadNote, logCall } = useCRMData();
+  const { leads, leadsLoading, updateLead, addLeadNote, addCallLog } = useCRMData();
   const { user } = useAuth();
   const { toast } = useToast();
   const [loading, setLoading] = useState(false);
@@ -50,6 +49,9 @@ const UpdateLeadStatus = () => {
     
     // Notes
     notes: '',
+
+    // Employee work pipeline (cloud synced via lead fields)
+    workStage: 'to_do',
   });
 
   useEffect(() => {
@@ -60,6 +62,7 @@ const UpdateLeadStatus = () => {
         interestLevel: lead.interestLevel || lead.interest_level || 'Warm',
         followUpDate: lead.followUpDate || lead.follow_up_date || '',
         followUpTime: lead.followUpTime || lead.follow_up_time || '',
+        workStage: lead.callAttempt || lead.call_attempt || 'to_do',
       }));
     }
   }, [lead]);
@@ -109,6 +112,8 @@ const UpdateLeadStatus = () => {
         status: formData.status,
         interestLevel: formData.interestLevel,
         interest_level: formData.interestLevel,
+        callAttempt: formData.workStage,
+        callStatus: formData.callOutcome || 'pending_action',
         updatedAt: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       };
@@ -140,22 +145,21 @@ const UpdateLeadStatus = () => {
       await updateLead(lead.id, updateData);
 
       // Log call if outcome provided
-      if (formData.callOutcome && logCall) {
-        await logCall({
+      if (formData.callOutcome) {
+        await addCallLog({
           leadId: lead.id,
-          lead_id: lead.id,
           employeeId: user.id,
-          employee_id: user.id,
-          callTime: new Date().toISOString(),
-          call_time: new Date().toISOString(),
+          leadName: lead.name,
+          projectName: lead.project || 'General',
+          type: 'Outgoing',
           status: formData.callOutcome,
-          duration: formData.callDuration || 0,
+          duration: Number(formData.callDuration) || 0,
           notes: formData.notes,
         });
       }
 
       // Create note
-      let noteText = `Status: ${formData.status}\nInterest: ${formData.interestLevel}`;
+      let noteText = `Status: ${formData.status}\nInterest: ${formData.interestLevel}\nWork Stage: ${formData.workStage}`;
       
       if (formData.callOutcome) {
         const outcomeLabels = {
@@ -196,17 +200,17 @@ const UpdateLeadStatus = () => {
   };
 
   const interestOptions = [
-    { value: 'Hot', label: 'Hot', sublabel: 'Ready to Buy', icon: Flame, color: 'red' },
-    { value: 'Warm', label: 'Warm', sublabel: 'Interested', icon: Wind, color: 'amber' },
-    { value: 'Cold', label: 'Cold', sublabel: 'Just Inquiring', icon: Snowflake, color: 'blue' },
+    { value: 'Hot', label: 'Hot', sublabel: 'Ready to Buy', icon: Flame, selectedClass: 'bg-red-50 border-red-300', iconClass: 'text-red-600' },
+    { value: 'Warm', label: 'Warm', sublabel: 'Interested', icon: Wind, selectedClass: 'bg-amber-50 border-amber-300', iconClass: 'text-amber-600' },
+    { value: 'Cold', label: 'Cold', sublabel: 'Just Inquiring', icon: Snowflake, selectedClass: 'bg-blue-50 border-blue-300', iconClass: 'text-blue-600' },
   ];
 
   const callOutcomes = [
-    { value: 'connected', label: 'Connected', icon: Phone, color: 'green' },
-    { value: 'not_answered', label: 'Not Answered', icon: PhoneMissed, color: 'yellow' },
-    { value: 'wrong_number', label: 'Wrong Number', icon: XCircle, color: 'red' },
-    { value: 'switched_off', label: 'Switched Off', icon: PhoneOff, color: 'gray' },
-    { value: 'busy', label: 'Busy', icon: Phone, color: 'orange' },
+    { value: 'connected', label: 'Connected', icon: Phone, selectedClass: 'bg-green-50 border-green-300 ring-1 ring-green-200', iconClass: 'text-green-600' },
+    { value: 'not_answered', label: 'Not Answered', icon: PhoneMissed, selectedClass: 'bg-yellow-50 border-yellow-300 ring-1 ring-yellow-200', iconClass: 'text-yellow-600' },
+    { value: 'wrong_number', label: 'Wrong Number', icon: XCircle, selectedClass: 'bg-red-50 border-red-300 ring-1 ring-red-200', iconClass: 'text-red-600' },
+    { value: 'switched_off', label: 'Switched Off', icon: PhoneOff, selectedClass: 'bg-gray-100 border-gray-300 ring-1 ring-gray-200', iconClass: 'text-gray-600' },
+    { value: 'busy', label: 'Busy', icon: Phone, selectedClass: 'bg-orange-50 border-orange-300 ring-1 ring-orange-200', iconClass: 'text-orange-600' },
   ];
 
   return (
@@ -229,7 +233,7 @@ const UpdateLeadStatus = () => {
         {/* QUICK ACTION TABS */}
         <div className="bg-white rounded-xl p-3 border shadow-sm">
           <Label className="text-xs font-semibold mb-2 block text-gray-600">QUICK ACTION</Label>
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-2 gap-2">
             <button
               type="button"
               onClick={() => {
@@ -265,6 +269,24 @@ const UpdateLeadStatus = () => {
             >
               Schedule Visit
             </button>
+            <button
+              type="button"
+              onClick={() => {
+                const tomorrow = addDays(new Date(), 1);
+                setFormData(prev => ({
+                  ...prev,
+                  status: 'FollowUp',
+                  actionType: 'call_log',
+                  callOutcome: 'not_answered',
+                  followUpDate: format(tomorrow, 'yyyy-MM-dd'),
+                  followUpTime: prev.followUpTime || '10:00',
+                  workStage: 'to_do',
+                }));
+              }}
+              className="p-2 rounded-lg text-xs font-medium bg-orange-100 text-orange-700 border border-orange-200"
+            >
+              Call Tomorrow
+            </button>
           </div>
         </div>
 
@@ -283,11 +305,11 @@ const UpdateLeadStatus = () => {
                     onClick={() => setFormData({ ...formData, callOutcome: outcome.value })}
                     className={`p-3 rounded-lg border-2 transition flex items-center gap-2 ${
                       isSelected
-                        ? `bg-${outcome.color}-50 border-${outcome.color}-300 ring-1 ring-${outcome.color}-200`
+                        ? outcome.selectedClass
                         : 'bg-white border-gray-200'
                     }`}
                   >
-                    <Icon size={18} className={isSelected ? `text-${outcome.color}-600` : 'text-gray-400'} />
+                    <Icon size={18} className={isSelected ? outcome.iconClass : 'text-gray-400'} />
                     <span className={`text-xs font-medium ${isSelected ? 'text-gray-900' : 'text-gray-500'}`}>
                       {outcome.label}
                     </span>
@@ -350,12 +372,12 @@ const UpdateLeadStatus = () => {
                   onClick={() => setFormData({ ...formData, interestLevel: option.value })}
                   className={`p-3 rounded-lg border-2 transition ${
                     isSelected
-                      ? `bg-${option.color}-50 border-${option.color}-300`
+                      ? option.selectedClass
                       : 'bg-white border-gray-200'
                   }`}
                 >
                   <div className="flex flex-col items-center gap-1">
-                    <Icon size={20} className={isSelected ? `text-${option.color}-600` : 'text-gray-300'} />
+                    <Icon size={20} className={isSelected ? option.iconClass : 'text-gray-300'} />
                     <p className={`font-bold text-xs ${isSelected ? 'text-gray-900' : 'text-gray-500'}`}>{option.label}</p>
                     <p className="text-[10px] text-gray-400">{option.sublabel}</p>
                   </div>
@@ -363,6 +385,30 @@ const UpdateLeadStatus = () => {
               );
             })}
           </div>
+        </div>
+
+        {/* EMPLOYEE WORK TRACKER */}
+        <div className="bg-white rounded-xl p-4 border shadow-sm">
+          <Label className="text-sm font-semibold mb-3 block text-gray-700">My Work Progress (Cloud Sync)</Label>
+          <div className="grid grid-cols-3 gap-2">
+            {[
+              { value: 'to_do', label: 'To Do', className: 'bg-slate-100 text-slate-700 border-slate-300' },
+              { value: 'doing', label: 'Doing', className: 'bg-blue-100 text-blue-700 border-blue-300' },
+              { value: 'did', label: 'Done', className: 'bg-green-100 text-green-700 border-green-300' },
+            ].map(stage => (
+              <button
+                key={stage.value}
+                type="button"
+                onClick={() => setFormData({ ...formData, workStage: stage.value })}
+                className={`p-2.5 rounded-lg text-xs font-semibold border-2 transition ${
+                  formData.workStage === stage.value ? stage.className : 'bg-white border-gray-200 text-gray-500'
+                }`}
+              >
+                {stage.label}
+              </button>
+            ))}
+          </div>
+          <p className="text-[11px] text-gray-500 mt-2">This updates call progress fields in cloud so manager can track what to do, doing, and done.</p>
         </div>
 
         {/* FOLLOW-UP */}

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,22 +2,26 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-const timestamp = Date.now();
+const buildId = process.env.BUILD_ID || `${Date.now()}`;
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __BUILD_ID__: JSON.stringify(buildId),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
   },
   build: {
+    manifest: true,
     chunkSizeWarningLimit: 3000,
     rollupOptions: {
       output: {
-        entryFileNames: `assets/[name]-[hash]-${timestamp}.js`,
-        chunkFileNames: `assets/[name]-[hash]-${timestamp}.js`,
-        assetFileNames: `assets/[name]-[hash]-${timestamp}.[ext]`,
+        entryFileNames: `assets/[name]-[hash]-${buildId}.js`,
+        chunkFileNames: `assets/[name]-[hash]-${buildId}.js`,
+        assetFileNames: `assets/[name]-[hash]-${buildId}.[ext]`,
         manualChunks: {
           'vendor-react': ['react', 'react-dom', 'react-router-dom'],
           'vendor-supabase': ['@supabase/supabase-js'],


### PR DESCRIPTION
### Motivation
- Provide deterministic, traceable build artifacts by embedding a stable `buildId` and emitting build metadata to `public/version.json` for deploy diagnostics.
- Expose a lightweight JSON endpoint at `/api/version` to allow runtime verification of deployed build and avoid cached index issues.
- Improve lead update UX and cloud-synced employee work tracking while standardizing call logging payloads.

### Description
- Introduce a build orchestration script `scripts/build.mjs` that generates `public/version.json` (with `buildId`, `buildTimestamp`, `gitCommit`, `gitBranch`) and then invokes `npx vite build`, and add `scripts/deploy-clean-rebuild.sh` to perform a clean rebuild; update `package.json` to use `node scripts/build.mjs` for `build` and add `build:clean` script.
- Update `vite.config.js` to use `process.env.BUILD_ID` (or fallback) as `buildId`, enable stable hashed asset filenames using that `buildId`, and expose `__BUILD_ID__` via `define`, and enable `manifest: true`.
- Add server-side endpoint `public/api/version.php` that returns `version.json` contents plus runtime `serverTime` and sets no-cache headers; update `public/.htaccess` to route `/api/version` to the PHP endpoint and ensure `index.html`, `version.json`, and `version.php` are not cached while keeping aggressive caching for hashed assets and images.
- Replace/augment `public/version.json` with new fields (`buildId`, `buildTimestamp`, `gitCommit`, `gitBranch`) to reflect the new build metadata format.
- Enhance CRM lead update page `src/crm/pages/UpdateLeadStatus.jsx` by adding `workStage` to the form state and syncing it to cloud fields, renaming and using `addCallLog` to record richer call log payloads, include `Work Stage` in lead notes, add a "Call Tomorrow" quick action, add a "My Work Progress (Cloud Sync)" UI block, and modernize option button styling (use `selectedClass`/`iconClass`) and layout tweaks (quick action grid columns, imports for `addDays`).

### Testing
- Ran the automated build via `npm run build` (which runs `node scripts/build.mjs` and `npx vite build`), and the build completed successfully and generated `public/version.json` and the `dist` assets with `buildId`-annotated filenames.
- Executed `npm run build:clean` (the provided `scripts/deploy-clean-rebuild.sh`) to verify clean rebuild workflow, which succeeded in producing a fresh `dist` output.
- No automated unit tests were added or modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa8d6711248326849a359af2ebd2a6)