### PR TITLE
Fix: Bottom sheets hidden behind MobileBottomNav

### DIFF
--- a/src/crm/pages/LeadDetail.jsx
+++ b/src/crm/pages/LeadDetail.jsx
@@ -27,28 +27,28 @@ import {
 } from 'lucide-react';
 
 const CALL_OUTCOMES = [
-  { id: 'Not Answered',  label: 'No Answer',    emoji: '\uD83D\uDCF5', cls: 'bg-gray-100 text-gray-700 border-gray-200' },
-  { id: 'Busy',          label: 'Busy',         emoji: '\uD83D\uDD34', cls: 'bg-red-50 text-red-700 border-red-200' },
-  { id: 'Connected',     label: 'Connected',    emoji: '\u2705', cls: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
-  { id: 'Switched Off',  label: 'Switched Off', emoji: '\uD83D\uDCF4', cls: 'bg-orange-50 text-orange-700 border-orange-200' },
+  { id: 'Not Answered',  label: 'No Answer',    emoji: '📵', cls: 'bg-gray-100 text-gray-700 border-gray-200' },
+  { id: 'Busy',          label: 'Busy',         emoji: '🔴', cls: 'bg-red-50 text-red-700 border-red-200' },
+  { id: 'Connected',     label: 'Connected',    emoji: '✅', cls: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
+  { id: 'Switched Off',  label: 'Switched Off', emoji: '📴', cls: 'bg-orange-50 text-orange-700 border-orange-200' },
 ];
 
 const LEAD_STATUSES = [
-  { id: 'FollowUp',      label: 'Follow Up',       emoji: '\uD83D\uDCC5' },
-  { id: 'SiteVisit',     label: 'Site Visit',      emoji: '\uD83D\uDCCD' },
-  { id: 'NotInterested', label: 'Not Interested',  emoji: '\u274C' },
-  { id: 'CallBackLater', label: 'Call Back Later', emoji: '\uD83D\uDD04' },
+  { id: 'FollowUp',      label: 'Follow Up',       emoji: '📅' },
+  { id: 'SiteVisit',     label: 'Site Visit',      emoji: '📍' },
+  { id: 'NotInterested', label: 'Not Interested',  emoji: '❌' },
+  { id: 'CallBackLater', label: 'Call Back Later', emoji: '🔄' },
 ];
 
 const QUICK_TAGS = [
-  { label: '\uD83D\uDCB0 Price Issue',      value: '#PriceIssue' },
-  { label: '\uD83D\uDCC5 Callback',         value: '#Callback' },
-  { label: '\uD83C\uDFE0 Site Visit?',      value: '#SiteVisit' },
-  { label: '\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67 Family Decision', value: '#FamilyDecision' },
-  { label: '\uD83C\uDFE6 Loan Needed',      value: '#LoanNeeded' },
-  { label: '\u2705 Very Interested',        value: '#VeryInterested' },
-  { label: '\u23F0 Not Available',          value: '#NotAvailable' },
-  { label: '\uD83D\uDD04 Follow Up',        value: '#FollowUp' },
+  { label: '💰 Price Issue',      value: '#PriceIssue' },
+  { label: '📅 Callback',         value: '#Callback' },
+  { label: '🏠 Site Visit?',      value: '#SiteVisit' },
+  { label: '👨‍👩‍👧 Family Decision', value: '#FamilyDecision' },
+  { label: '🏦 Loan Needed',      value: '#LoanNeeded' },
+  { label: '✅ Very Interested',  value: '#VeryInterested' },
+  { label: '⏰ Not Available',    value: '#NotAvailable' },
+  { label: '🔄 Follow Up',        value: '#FollowUp' },
 ];
 
 const PAYMENT_MODES = ['Cash', 'Cheque', 'NEFT', 'UPI'];
@@ -84,10 +84,10 @@ const formatPhone = (p) => {
 
 const formatINR = (val) => {
   const n = Number(val) || 0;
-  if (n >= 10000000) return `\u20B9${(n / 10000000).toFixed(2)} Cr`;
-  if (n >= 100000)   return `\u20B9${(n / 100000).toFixed(2)} L`;
-  if (n >= 1000)     return `\u20B9${n.toLocaleString('en-IN')}`;
-  return `\u20B9${n}`;
+  if (n >= 10000000) return `₹${(n / 10000000).toFixed(2)} Cr`;
+  if (n >= 100000)   return `₹${(n / 100000).toFixed(2)} L`;
+  if (n >= 1000)     return `₹${n.toLocaleString('en-IN')}`;
+  return `₹${n}`;
 };
 
 const LeadDetail = () => {
@@ -206,7 +206,14 @@ const LeadDetail = () => {
       });
       const patch = { last_activity: new Date().toISOString() };
       if (leadStatus) patch.status = leadStatus;
-      if (followDate) { patch.follow_up_date = followDate; patch.followUpDate = followDate; }
+      if (leadStatus === 'NotInterested') {
+        patch.follow_up_date = null;
+        patch.followUpDate = null;
+        setFollowDate('');
+      } else if (followDate) {
+        patch.follow_up_date = followDate;
+        patch.followUpDate = followDate;
+      }
       await updateLead(id, patch);
       if (quickNote) await addLeadNote(id, quickNote, user?.name || 'User');
       if (leadStatus === 'SiteVisit' && followDate) {
@@ -216,7 +223,7 @@ const LeadDetail = () => {
           visitDate: followDate, status: 'Scheduled', notes: quickNote || null,
         });
       }
-      toast({ title: 'Logged!', description: leadStatus ? `Status \u2192 ${leadStatus}` : 'Call saved' });
+      toast({ title: 'Logged!', description: leadStatus ? `Status → ${leadStatus}` : 'Call saved' });
       setShowSheet(false);
       setOutcome(''); setLeadStatus(''); setFollowDate(''); setQuickNote('');
     } catch (e) {
@@ -251,7 +258,7 @@ const LeadDetail = () => {
         bookingDate:   new Date().toISOString().split('T')[0],
         notes:         bookingForm.notes || '',
       });
-      toast({ title: '\uD83C\uDFC6 Booking confirmed!', description: `Unit ${bookingForm.unitNumber} booked for ${formatINR(bookingForm.bookingAmount)}` });
+      toast({ title: '🏆 Booking confirmed!', description: `Unit ${bookingForm.unitNumber} booked for ${formatINR(bookingForm.bookingAmount)}` });
       setShowBookingSheet(false);
       setBookingForm({ bookingAmount: '', tokenAmount: '', partialPayment: '', unitNumber: '', paymentMode: 'Cash', notes: '' });
     } catch (e) {
@@ -400,10 +407,10 @@ const LeadDetail = () => {
         <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-3">Details</p>
         <div className="grid grid-cols-2 gap-2.5">
           {[
-            { label: 'Budget',  value: lead.budget || '\u2014',   icon: '\uD83D\uDCB0' },
-            { label: 'Project', value: lead.project || 'Not set',  icon: '\uD83C\uDFD7\uFE0F' },
-            { label: 'Source',  value: lead.source || '\u2014',   icon: '\uD83D\uDCCC' },
-            { label: 'Email',   value: lead.email || 'Not given',  icon: '\u2709\uFE0F' },
+            { label: 'Budget',  value: lead.budget || '—',   icon: '💰' },
+            { label: 'Project', value: lead.project || 'Not set',  icon: '🏗️' },
+            { label: 'Source',  value: lead.source || '—',   icon: '📌' },
+            { label: 'Email',   value: lead.email || 'Not given',  icon: '✉️' },
           ].map(item => (
             <div key={item.label} className="bg-gray-50 rounded-xl p-3">
               <p className="text-[10px] text-gray-400 uppercase tracking-wide">{item.label}</p>
@@ -432,7 +439,7 @@ const LeadDetail = () => {
         {(lead.assignedToName || lead.assigned_to_name) && (
           <p className="text-[10px] text-gray-300 mt-3">
             Assigned by {lead.assignedToName || lead.assigned_to_name}
-            {(lead.assignedAt || lead.assigned_at) && ` \u00B7 ${timeAgo(lead.assignedAt || lead.assigned_at)}`}
+            {(lead.assignedAt || lead.assigned_at) && ` · ${timeAgo(lead.assignedAt || lead.assigned_at)}`}
           </p>
         )}
       </div>
@@ -493,8 +500,8 @@ const LeadDetail = () => {
                           : `Booking${item.amount ? ` - ${formatINR(item.amount)}` : ''}`}
                       </p>
                       <p className="text-[10px] text-gray-400 mt-0.5">
-                        {item.time ? format(new Date(item.time), 'dd MMM yyyy, h:mm a') : '\u2014'}
-                        {item.employee ? ` \u00B7 ${item.employee}` : ''}
+                        {item.time ? format(new Date(item.time), 'dd MMM yyyy, h:mm a') : '—'}
+                        {item.employee ? ` · ${item.employee}` : ''}
                       </p>
                       {item.notes && <p className="text-xs text-gray-500 mt-1 line-clamp-2">{item.notes}</p>}
                     </div>
@@ -591,17 +598,17 @@ const LeadDetail = () => {
       {/* ════════════════════════════════════════════════ */}
       {showSheet && (
         <>
-          <div className="fixed inset-0 bg-black/50 z-40 touch-none" onClick={() => setShowSheet(false)} />
-          <div className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-3xl shadow-2xl"
+          <div className="fixed inset-0 bg-black/50 z-[60] touch-none" onClick={() => setShowSheet(false)} />
+          <div className="fixed bottom-0 left-0 right-0 z-[70] bg-white rounded-t-3xl shadow-2xl"
                style={{ maxHeight: '94vh', overflowY: 'auto', WebkitOverflowScrolling: 'touch' }}>
             <div className="flex justify-center pt-3 pb-1">
               <div className="w-10 h-1 bg-gray-200 rounded-full" />
             </div>
-            <div className="px-4 pb-8">
+            <div className="px-4 pb-24">
               <div className="flex items-center justify-between mb-5">
                 <div>
                   <p className="font-black text-[#0F3A5F] text-lg leading-tight">{lead.name}</p>
-                  <p className="text-xs text-gray-400">{formatPhone(lead.phone)} \u00B7 Log call outcome</p>
+                  <p className="text-xs text-gray-400">{formatPhone(lead.phone)} · Log call outcome</p>
                 </div>
                 <button onClick={() => setShowSheet(false)}
                   className="p-2 rounded-full bg-gray-100 active:bg-gray-200 touch-manipulation">
@@ -610,7 +617,7 @@ const LeadDetail = () => {
               </div>
 
               {/* Step 1 */}
-              <p className="text-[10px] font-black text-gray-400 uppercase tracking-widest mb-2">1 \u00B7 What happened on the call?</p>
+              <p className="text-[10px] font-black text-gray-400 uppercase tracking-widest mb-2">1 · What happened on the call?</p>
               <div className="grid grid-cols-2 gap-2 mb-5">
                 {CALL_OUTCOMES.map(o => (
                   <button key={o.id} onClick={() => setOutcome(o.id)}
@@ -623,10 +630,13 @@ const LeadDetail = () => {
               </div>
 
               {/* Step 2 */}
-              <p className="text-[10px] font-black text-gray-400 uppercase tracking-widest mb-2">2 \u00B7 Update Lead Status</p>
+              <p className="text-[10px] font-black text-gray-400 uppercase tracking-widest mb-2">2 · Update Lead Status</p>
               <div className="grid grid-cols-2 gap-2 mb-5">
                 {LEAD_STATUSES.map(s => (
-                  <button key={s.id} onClick={() => setLeadStatus(leadStatus === s.id ? '' : s.id)}
+                  <button key={s.id} onClick={() => {
+                    setLeadStatus(leadStatus === s.id ? '' : s.id);
+                    if (s.id === 'NotInterested') setFollowDate('');
+                  }}
                     className={`flex items-center gap-2 px-3 py-3 rounded-2xl border-2 text-sm font-semibold transition-all touch-manipulation ${
                       leadStatus === s.id ? 'border-[#D4AF37] bg-[#D4AF37]/15 text-[#0F3A5F] shadow-sm scale-[1.02]' : 'border-gray-100 bg-gray-50 text-gray-700'
                     }`}>
@@ -635,29 +645,33 @@ const LeadDetail = () => {
                 ))}
               </div>
 
-              {/* Step 3 */}
-              <p className="text-[10px] font-black text-gray-400 uppercase tracking-widest mb-2">
-                {leadStatus === 'SiteVisit' ? '3 \u00B7 Schedule Visit Date' : '3 \u00B7 Follow-up Date (optional)'}
-              </p>
-              <div className="flex gap-2 mb-2">
-                {[{ label: 'Tomorrow', days: 1 }, { label: '3 Days', days: 3 }, { label: 'Next Week', days: 7 }].map(opt => {
-                  const target = new Date(); target.setDate(target.getDate() + opt.days);
-                  const targetStr = target.toISOString().split('T')[0];
-                  return (
-                    <button key={opt.label} onClick={() => setFollowDate(targetStr)}
-                      className={`px-3 py-2 rounded-xl text-xs font-semibold border transition-all ${
-                        followDate === targetStr ? 'border-blue-400 bg-blue-50 text-blue-700' : 'border-gray-200 bg-white text-gray-600'
-                      }`}>
-                      {opt.label}
-                    </button>
-                  );
-                })}
-              </div>
-              <input type="date" min={today} value={followDate} onChange={e => setFollowDate(e.target.value)}
-                className="w-full border-2 border-gray-100 rounded-2xl px-4 py-3 text-sm font-medium focus:outline-none focus:border-[#0F3A5F] mb-5" />
+              {/* Step 3 - Hidden when NotInterested */}
+              {leadStatus !== 'NotInterested' && (
+                <>
+                  <p className="text-[10px] font-black text-gray-400 uppercase tracking-widest mb-2">
+                    {leadStatus === 'SiteVisit' ? '3 · Schedule Visit Date' : '3 · Follow-up Date (optional)'}
+                  </p>
+                  <div className="flex gap-2 mb-2">
+                    {[{ label: 'Tomorrow', days: 1 }, { label: '3 Days', days: 3 }, { label: 'Next Week', days: 7 }].map(opt => {
+                      const target = new Date(); target.setDate(target.getDate() + opt.days);
+                      const targetStr = target.toISOString().split('T')[0];
+                      return (
+                        <button key={opt.label} onClick={() => setFollowDate(targetStr)}
+                          className={`px-3 py-2 rounded-xl text-xs font-semibold border transition-all ${
+                            followDate === targetStr ? 'border-blue-400 bg-blue-50 text-blue-700' : 'border-gray-200 bg-white text-gray-600'
+                          }`}>
+                          {opt.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <input type="date" min={today} value={followDate} onChange={e => setFollowDate(e.target.value)}
+                    className="w-full border-2 border-gray-100 rounded-2xl px-4 py-3 text-sm font-medium focus:outline-none focus:border-[#0F3A5F] mb-5" />
+                </>
+              )}
 
               {/* Step 4 */}
-              <p className="text-[10px] font-black text-gray-400 uppercase tracking-widest mb-2">4 \u00B7 Quick Note (optional)</p>
+              <p className="text-[10px] font-black text-gray-400 uppercase tracking-widest mb-2">4 · Quick Note (optional)</p>
               <div className="mb-5">
                 <SmartNotesInput
                   value={quickNote}
@@ -698,19 +712,19 @@ const LeadDetail = () => {
       {/* ════════════════════════════════════════════════ */}
       {showBookingSheet && (
         <>
-          <div className="fixed inset-0 bg-black/50 z-40 touch-none" onClick={() => setShowBookingSheet(false)} />
-          <div className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-3xl shadow-2xl"
+          <div className="fixed inset-0 bg-black/50 z-[60] touch-none" onClick={() => setShowBookingSheet(false)} />
+          <div className="fixed bottom-0 left-0 right-0 z-[70] bg-white rounded-t-3xl shadow-2xl"
                style={{ maxHeight: '94vh', overflowY: 'auto', WebkitOverflowScrolling: 'touch' }}>
             <div className="flex justify-center pt-3 pb-1">
               <div className="w-10 h-1 bg-gray-200 rounded-full" />
             </div>
-            <div className="px-4 pb-8">
+            <div className="px-4 pb-24">
               <div className="flex items-center justify-between mb-5">
                 <div>
                   <p className="font-black text-[#0F3A5F] text-lg leading-tight flex items-center gap-2">
                     <Trophy size={20} className="text-[#D4AF37]" /> Book This Lead
                   </p>
-                  <p className="text-xs text-gray-400">{lead.name} \u00B7 {lead.project || 'No project'}</p>
+                  <p className="text-xs text-gray-400">{lead.name} · {lead.project || 'No project'}</p>
                 </div>
                 <button onClick={() => setShowBookingSheet(false)}
                   className="p-2 rounded-full bg-gray-100 active:bg-gray-200 touch-manipulation">
@@ -727,7 +741,7 @@ const LeadDetail = () => {
                   <div>
                     <label className="text-xs font-semibold text-gray-600 mb-1 block">Booking Amount *</label>
                     <div className="relative">
-                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm font-bold">\u20B9</span>
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm font-bold">₹</span>
                       <input type="number" placeholder="e.g. 5000000"
                         value={bookingForm.bookingAmount}
                         onChange={e => updateBookingField('bookingAmount', e.target.value)}
@@ -737,7 +751,7 @@ const LeadDetail = () => {
                   <div>
                     <label className="text-xs font-semibold text-gray-600 mb-1 block">Token Amount * (collected today)</label>
                     <div className="relative">
-                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm font-bold">\u20B9</span>
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm font-bold">₹</span>
                       <input type="number" placeholder="e.g. 100000"
                         value={bookingForm.tokenAmount}
                         onChange={e => updateBookingField('tokenAmount', e.target.value)}
@@ -747,7 +761,7 @@ const LeadDetail = () => {
                   <div>
                     <label className="text-xs font-semibold text-gray-600 mb-1 block">Partial Payment (optional)</label>
                     <div className="relative">
-                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm font-bold">\u20B9</span>
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm font-bold">₹</span>
                       <input type="number" placeholder="0"
                         value={bookingForm.partialPayment}
                         onChange={e => updateBookingField('partialPayment', e.target.value)}


### PR DESCRIPTION
## 🐛 Problem

Bottom sheets (Log Call & Booking) were rendering behind the `MobileBottomNav` on mobile devices:
- **Save button** completely hidden
- Both backdrop and sheet panel had same `z-index` (z-40/z-50) as MobileBottomNav (z-50)
- Insufficient bottom padding caused content to be cut off

## ✅ Solution

### Z-Index Fixes
- **Backdrop**: `z-40` → `z-[60]`
- **Sheet Panel**: `z-50` → `z-[70]`

### Padding Fix
- **Inner Content**: `pb-8` (32px) → `pb-24` (96px)
- Provides clearance above MobileBottomNav safe area

### Bonus Fix: "Not Interested" Follow-up Date
- **Hidden Step 3** when `leadStatus === 'NotInterested'`
- **Auto-clears** `follow_up_date` when saving with NotInterested status
- Prevents dead leads from appearing in Today/Tomorrow tabs

## 📝 Changes

### Files Modified
1. **src/crm/pages/LeadDetail.jsx**
   - Updated both Log Call and Booking bottom sheets
   - Added conditional rendering for Step 3 (follow-up date picker)
   - Auto-clears follow-up date when NotInterested selected
   - DB patch explicitly sets `follow_up_date` and `followUpDate` to `null` for NotInterested

## 🧪 Testing

**Mobile (Chrome/Safari)**:
1. Open LeadDetail page
2. Tap "Log Call" or "Book" button
3. ✅ Sheet should appear **above** bottom nav
4. ✅ Save button fully visible and tappable
5. Select "Not Interested" status
6. ✅ Step 3 (follow-up date picker) should disappear

**Desktop**:
- No changes to desktop behavior
- Bottom sheets still work as expected

---

**Ready to merge!** All critical mobile UX issues fixed.