### PR TITLE
Fix follow-up reminders for terminal lead statuses

### DIFF
--- a/src/crm/components/FollowUpReminders.jsx
+++ b/src/crm/components/FollowUpReminders.jsx
@@ -29,8 +29,9 @@ const FollowUpReminders = () => {
     const myLeads = leads.filter(l =>
       (l.assignedTo === userId || l.assigned_to === userId) &&
       (l.followUpDate || l.follow_up_date) &&
-      l.status !== 'Booked' && 
-      l.status !== 'Lost'
+      l.status !== 'Booked' &&
+      l.status !== 'Lost' &&
+      l.status !== 'NotInterested'
     );
 
     // Normalize follow-up date field and sort by earliest first
@@ -45,14 +46,13 @@ const FollowUpReminders = () => {
     });
 
     // Group by priority
-    const overdueLeads = sortedLeads.filter(l => isPast(parseLocalDate(l.followUpDate)) && !isToday(parseLocalDate(l.followUpDate)));
-    const todayLeads = sortedLeads.filter(l => isToday(parseLocalDate(l.followUpDate)));
-    const tomorrowLeads = sortedLeads.filter(l => isTomorrow(parseLocalDate(l.followUpDate)));
-    const upcomingLeads = sortedLeads.filter(l => 
-      !isPast(parseLocalDate(l.followUpDate)) && 
-      !isToday(parseLocalDate(l.followUpDate)) && 
-      !isTomorrow(parseLocalDate(l.followUpDate))
-    ).slice(0, 5);
+    const overdueLeads = sortedLeads.filter(l => { const d = parseLocalDate(l.followUpDate); return d && isPast(d) && !isToday(d); });
+    const todayLeads = sortedLeads.filter(l => { const d = parseLocalDate(l.followUpDate); return d && isToday(d); });
+    const tomorrowLeads = sortedLeads.filter(l => { const d = parseLocalDate(l.followUpDate); return d && isTomorrow(d); });
+    const upcomingLeads = sortedLeads.filter(l => {
+      const d = parseLocalDate(l.followUpDate);
+      return d && !isPast(d) && !isToday(d) && !isTomorrow(d);
+    }).slice(0, 5);
 
     setReminders({
       overdue: overdueLeads,
@@ -127,7 +127,7 @@ const FollowUpReminders = () => {
         <p className="text-xs text-gray-600">{lead.project || 'General'}</p>
         <p className="text-xs text-gray-500 mt-1">
           <Calendar className="inline h-3 w-3 mr-1" />
-          {format(parseLocalDate(lead.followUpDate), 'MMM dd, yyyy')}
+          {parseLocalDate(lead.followUpDate) ? format(parseLocalDate(lead.followUpDate), 'MMM dd, yyyy') : lead.followUpDate}
         </p>
       </div>
       <div className="flex gap-2">

--- a/src/crm/hooks/useCRMData.js
+++ b/src/crm/hooks/useCRMData.js
@@ -476,13 +476,14 @@ export const useCRMData = () => {
     finally { setBookingsLoading(false); }
   };
 
+  // ✅ FIX: addBookingLog now clears follow_up_date when marking Booked,
+  // and calls updateLead BEFORE fetchBookings to avoid Realtime race condition.
   const addBookingLog = async (log) => {
     try {
       const result = await addBooking(log);
       if (result.success) {
-        await fetchBookings();
         if (log.leadId) {
-          const leadUpdate = { status: 'Booked' };
+          const leadUpdate = { status: 'Booked', follow_up_date: null, followUpDate: null };
           if (log.tokenAmount    !== undefined) leadUpdate.tokenAmount    = log.tokenAmount;
           if (log.bookingAmount  !== undefined) leadUpdate.bookingAmount  = log.bookingAmount;
           if (log.partialPayment !== undefined) leadUpdate.partialPayment = log.partialPayment;
@@ -490,6 +491,7 @@ export const useCRMData = () => {
           if (log.paymentMode    !== undefined) leadUpdate.paymentMode    = log.paymentMode;
           await updateLead(log.leadId, leadUpdate);
         }
+        await fetchBookings();
         return result.data;
       }
       return null;

--- a/src/crm/pages/EmployeeCRMHome.jsx
+++ b/src/crm/pages/EmployeeCRMHome.jsx
@@ -213,7 +213,7 @@ const EmployeeCRMHome = () => {
   const followUpLeads = useMemo(() => {
     const grouped = { overdue: [], today: [], tomorrow: [], thisWeek: [], noDate: [] };
     analyzedLeads.forEach(l => {
-      if (l._normalizedStatus === LEAD_STATUS.LOST) return;
+      if (l._normalizedStatus === LEAD_STATUS.LOST || l._normalizedStatus === LEAD_STATUS.BOOKED) return;
       if (l._followUpPriority === 1) grouped.overdue.push(l);
       else if (l._followUpPriority === 2) grouped.today.push(l);
       else if (l._followUpPriority === 3) grouped.tomorrow.push(l);
@@ -327,11 +327,15 @@ const EmployeeCRMHome = () => {
         closeAction();
       } else if (outcome.id === 'booked') {
         updates.status = 'Booked';
+        updates.follow_up_date = null;
+        updates.followUpDate = null;
         await updateLead(actionLead.id, updates);
         toast({ title: 'Booked!', description: `${actionLead.name} marked as Booked` });
         closeAction();
       } else if (outcome.id === 'not_interested') {
         updates.status = 'Lost';
+        updates.follow_up_date = null;
+        updates.followUpDate = null;
         await updateLead(actionLead.id, updates);
         toast({ title: 'Marked Lost', description: `${actionLead.name} not interested` });
         closeAction();
@@ -349,7 +353,7 @@ const EmployeeCRMHome = () => {
       if (followUpDate) { updates.followUpDate = followUpDate; updates.follow_up_date = followUpDate; }
       if (callNote) updates.notes = `${actionLead.notes || ''}\n[${new Date().toLocaleString('en-IN')}] ${callNote}`.trim();
       await updateLead(actionLead.id, updates);
-      toast({ title: 'Follow-up Set', description: followUpDate ? `Reminder for ${format(parseLocalDate(followUpDate), 'MMM dd')}` : 'Status updated' });
+      toast({ title: 'Follow-up Set', description: followUpDate && parseLocalDate(followUpDate) ? `Reminder for ${format(parseLocalDate(followUpDate), 'MMM dd')}` : 'Status updated' });
       closeAction();
     } catch (err) {
       toast({ title: 'Error', description: err.message, variant: 'destructive' });
@@ -684,7 +688,7 @@ const EmployeeCRMHome = () => {
                   <div className="bg-blue-50 border border-blue-200 rounded-2xl p-3 text-center">
                     <p className="text-xs text-blue-600 font-medium">Follow-up set for</p>
                     <p className="text-lg font-bold text-blue-800">
-                      {followUpDate ? format(parseLocalDate(followUpDate), 'EEE, MMM dd') : 'Today'}
+                      {followUpDate && parseLocalDate(followUpDate) ? format(parseLocalDate(followUpDate), 'EEE, MMM dd') : 'Today'}
                     </p>
                   </div>
                   <Textarea placeholder="Notes for next call..." value={callNote}

--- a/src/crm/pages/LeadDetail.jsx
+++ b/src/crm/pages/LeadDetail.jsx
@@ -207,7 +207,8 @@ const LeadDetail = () => {
       });
       const patch = { last_activity: new Date().toISOString() };
       if (leadStatus) patch.status = leadStatus;
-      if (leadStatus === 'NotInterested') {
+      const isTerminal = ['NotInterested', 'Lost', 'Booked'].includes(leadStatus);
+      if (isTerminal) {
         patch.follow_up_date = null;
         patch.followUpDate = null;
         setFollowDate('');
@@ -372,7 +373,7 @@ const LeadDetail = () => {
           </button>
         </a>
 
-        {followUpRaw && (
+        {followUpRaw && parseLocalDate(followUpRaw) && (
           <div className={`flex items-center gap-2 px-3 py-2 rounded-xl text-sm mb-3 font-medium ${
             isOverdue ? 'bg-red-50 text-red-700' : isFollowToday ? 'bg-emerald-50 text-emerald-700' : 'bg-amber-50 text-amber-700'
           }`}>

--- a/src/crm/pages/MyLeads.jsx
+++ b/src/crm/pages/MyLeads.jsx
@@ -151,10 +151,13 @@ const MyLeads = () => {
       });
   }, [leads, calls, userId, sortBy]);
 
+  const TERMINAL_STATUSES = ['NotInterested', 'Lost', 'Booked'];
+
   // ✅ Schedule counts — always computed live from latest leads state
   const scheduleCounts = useMemo(() => {
     let overdue = 0, todayCount = 0, tomorrowCount = 0;
     myLeads.forEach(l => {
+      if (TERMINAL_STATUSES.includes(l.status)) return;
       const fu = l.follow_up_date || l.followUpDate;
       if (!fu) return;
       try {
@@ -172,16 +175,19 @@ const MyLeads = () => {
     let arr = myLeads;
     if (tab === 'overdue') {
       arr = arr.filter(l => {
+        if (TERMINAL_STATUSES.includes(l.status)) return false;
         const fu = l.follow_up_date || l.followUpDate;
         try { const d = parseLocalDate(fu); return d && isPast(d) && !isToday(d); } catch { return false; }
       });
     } else if (tab === 'today') {
       arr = arr.filter(l => {
+        if (TERMINAL_STATUSES.includes(l.status)) return false;
         const fu = l.follow_up_date || l.followUpDate;
         try { const d = parseLocalDate(fu); return d && isToday(d); } catch { return false; }
       });
     } else if (tab === 'tomorrow') {
       arr = arr.filter(l => {
+        if (TERMINAL_STATUSES.includes(l.status)) return false;
         const fu = l.follow_up_date || l.followUpDate;
         try { const d = parseLocalDate(fu); return d && isTomorrow(d); } catch { return false; }
       });
@@ -223,7 +229,14 @@ const MyLeads = () => {
       });
       const patch = { last_activity: new Date().toISOString() };
       if (newStatus)  patch.status         = newStatus;
-      if (followDate) { patch.follow_up_date = followDate; patch.followUpDate = followDate; }
+      const isTerminal = ['NotInterested', 'Lost', 'Booked'].includes(newStatus);
+      if (isTerminal) {
+        patch.follow_up_date = null;
+        patch.followUpDate = null;
+      } else if (followDate) {
+        patch.follow_up_date = followDate;
+        patch.followUpDate = followDate;
+      }
       await updateLead(quickLead.id, patch);
       toast({ title: 'Logged!', description: newStatus ? `Status \u2192 ${newStatus}` : 'Call saved' });
       setQuickLead(null); setOutcome(''); setNewStatus(''); setFollowDate(''); setQuickNote('');
@@ -473,7 +486,7 @@ const MyLeads = () => {
                 <div className="flex items-center gap-3 mt-2 text-xs text-gray-400">
                   {lead.project && <span className="truncate max-w-[120px]">\uD83C\uDFD7\uFE0F {lead.project}</span>}
                   {lead.budget  && <span>\uD83D\uDCB0 {lead.budget}</span>}
-                  {fu && (
+                  {fu && parseLocalDate(fu) && (
                     <span className={`flex items-center gap-1 ${
                       overdueFlag ? 'text-red-500' : todayFlag ? 'text-amber-600' : tomorrowFlag ? 'text-blue-600' : 'text-gray-400'
                     }`}>


### PR DESCRIPTION
## Summary
This PR improves the handling of follow-up reminders and dates for leads with terminal statuses (Booked, Lost, NotInterested). It prevents these leads from appearing in follow-up reminder lists and clears their follow-up dates when transitioned to terminal statuses.

## Key Changes

- **FollowUpReminders.jsx**: Added 'NotInterested' to the list of excluded statuses and added null checks when parsing follow-up dates to prevent formatting errors
- **MyLeads.jsx**: 
  - Introduced `TERMINAL_STATUSES` constant and applied it consistently across schedule count calculations and tab filtering
  - Clear follow-up dates when leads transition to terminal statuses (Booked, Lost, NotInterested)
  - Added null checks before formatting dates
- **EmployeeCRMHome.jsx**:
  - Exclude both LOST and BOOKED statuses from follow-up lead grouping
  - Clear follow-up dates when marking leads as Booked or NotInterested
  - Added null checks before formatting dates in toast messages and UI display
- **useCRMData.js**: Fixed `addBookingLog` to clear follow-up dates when marking a lead as Booked, and reordered operations to call `updateLead` before `fetchBookings` to avoid race conditions
- **LeadDetail.jsx**: Expanded terminal status check to include all three statuses (NotInterested, Lost, Booked) when clearing follow-up dates, and added null check before displaying follow-up date

## Implementation Details

- All date formatting now includes null checks via `parseLocalDate(fu) &&` pattern to prevent errors when dates are invalid or null
- Terminal statuses are consistently treated across all components to prevent leads from appearing in follow-up reminders
- Follow-up dates are automatically cleared when leads reach terminal statuses, ensuring data consistency

https://claude.ai/code/session_019anZTwDqaxjhqrbczanm6y