### PR TITLE
style: refresh employee mobile lead UI to match mockup

### DIFF
--- a/src/crm/pages/EmployeeAddLead.jsx
+++ b/src/crm/pages/EmployeeAddLead.jsx
@@ -106,25 +106,25 @@ const EmployeeAddLead = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-slate-50 p-4 md:p-6">
-      <div className="max-w-3xl mx-auto">
+    <div className="min-h-screen bg-[#F6F7F9] px-3 py-4 md:p-6">
+      <div className="max-w-2xl mx-auto">
 
         {/* Header */}
-        <div className="flex items-center gap-4 mb-6">
-          <Button variant="outline" size="icon" onClick={() => navigate('/crm/sales/my-leads')} className="rounded-full">
+        <div className="flex items-center gap-3 mb-5">
+          <Button variant="outline" size="icon" onClick={() => navigate('/crm/sales/my-leads')} className="rounded-full h-9 w-9 border-gray-300 bg-white">
             <ArrowLeft size={20} />
           </Button>
           <div>
-            <h1 className="text-2xl md:text-3xl font-bold text-gray-900 flex items-center gap-2">
-              <UserPlus size={28} className="text-emerald-600" />
+            <h1 className="text-[28px] font-bold text-[#1D222C] flex items-center gap-2">
+              <UserPlus size={24} className="text-[#155C52]" />
               Add New Lead
             </h1>
-            <p className="text-sm text-gray-500 mt-1">Submit a new lead and continue in My Leads</p>
+            <p className="text-xs text-gray-500 mt-1">Fill details and save lead.</p>
           </div>
         </div>
 
         {/* Review notice */}
-        <div className="flex items-center gap-3 p-3 mb-4 bg-indigo-50 border border-indigo-200 rounded-lg text-sm text-indigo-800">
+        <div className="flex items-center gap-3 p-3 mb-4 bg-[#F5F8FF] border border-[#DEE8FF] rounded-xl text-sm text-[#34528A]">
           <ShieldCheck size={18} className="text-indigo-600 shrink-0" />
           <span>
             Leads you submit are marked <strong>Pending Review</strong> and are visible to superadmin/admin in Employee Submitted Leads.
@@ -134,16 +134,16 @@ const EmployeeAddLead = () => {
         <form onSubmit={handleSubmit} className="space-y-6">
 
           {/* Section 1: Customer Basic Info */}
-          <Card className="border-gray-200 shadow-md">
-            <CardHeader className="bg-gradient-to-r from-emerald-50 to-teal-50 border-b py-3">
+          <Card className="border-gray-200 rounded-2xl shadow-sm">
+            <CardHeader className="bg-white border-b py-3">
               <CardTitle className="text-base flex items-center gap-2">
-                <Phone size={18} className="text-emerald-600" /> Customer Information
+                <Phone size={16} className="text-[#155C52]" /> Customer Information
               </CardTitle>
             </CardHeader>
             <CardContent className="p-4 md:p-6 space-y-4">
               {/* Submitter stamp */}
-              <div className="flex items-center gap-2 p-3 bg-emerald-50 border border-emerald-200 rounded-lg text-sm text-emerald-800">
-                <User size={16} className="text-emerald-600 shrink-0" />
+              <div className="flex items-center gap-2 p-3 bg-[#ECF7F3] border border-[#CDEBDE] rounded-xl text-sm text-[#1A6D5D]">
+                <User size={16} className="text-[#155C52] shrink-0" />
                 <span>Submitting as <strong>{user?.name || user?.username}</strong> &middot; {new Date().toLocaleString('en-IN', { dateStyle: 'medium', timeStyle: 'short' })}</span>
               </div>
 
@@ -173,10 +173,10 @@ const EmployeeAddLead = () => {
           </Card>
 
           {/* Section 2: Location */}
-          <Card className="border-gray-200 shadow-md">
-            <CardHeader className="bg-gradient-to-r from-blue-50 to-indigo-50 border-b py-3">
+          <Card className="border-gray-200 rounded-2xl shadow-sm">
+            <CardHeader className="bg-white border-b py-3">
               <CardTitle className="text-base flex items-center gap-2">
-                <MapPin size={18} className="text-blue-600" /> Location Details
+                <MapPin size={16} className="text-[#155C52]" /> Location Details
               </CardTitle>
             </CardHeader>
             <CardContent className="p-4 md:p-6 space-y-4">
@@ -198,10 +198,10 @@ const EmployeeAddLead = () => {
           </Card>
 
           {/* Section 3: Lead / Property Interest */}
-          <Card className="border-gray-200 shadow-md">
-            <CardHeader className="bg-gradient-to-r from-amber-50 to-orange-50 border-b py-3">
+          <Card className="border-gray-200 rounded-2xl shadow-sm">
+            <CardHeader className="bg-white border-b py-3">
               <CardTitle className="text-base flex items-center gap-2">
-                <Briefcase size={18} className="text-amber-600" /> Property Interest
+                <Briefcase size={16} className="text-[#155C52]" /> Property Interest
               </CardTitle>
             </CardHeader>
             <CardContent className="p-4 md:p-6 space-y-4">
@@ -301,10 +301,10 @@ const EmployeeAddLead = () => {
           </Card>
 
           {/* Section 4: Conversation Details */}
-          <Card className="border-gray-200 shadow-md">
-            <CardHeader className="bg-gradient-to-r from-purple-50 to-violet-50 border-b py-3">
+          <Card className="border-gray-200 rounded-2xl shadow-sm">
+            <CardHeader className="bg-white border-b py-3">
               <CardTitle className="text-base flex items-center gap-2">
-                <MessageSquare size={18} className="text-purple-600" /> Conversation Details
+                <MessageSquare size={16} className="text-[#155C52]" /> Conversation Details
               </CardTitle>
             </CardHeader>
             <CardContent className="p-4 md:p-6 space-y-4">
@@ -324,10 +324,10 @@ const EmployeeAddLead = () => {
           </Card>
 
           {/* Section 5: Site Visit */}
-          <Card className="border-gray-200 shadow-md">
-            <CardHeader className="bg-gradient-to-r from-rose-50 to-pink-50 border-b py-3">
+          <Card className="border-gray-200 rounded-2xl shadow-sm">
+            <CardHeader className="bg-white border-b py-3">
               <CardTitle className="text-base flex items-center gap-2">
-                <Calendar size={18} className="text-rose-600" /> Site Visit
+                <Calendar size={16} className="text-[#155C52]" /> Site Visit
               </CardTitle>
             </CardHeader>
             <CardContent className="p-4 md:p-6 space-y-4">
@@ -351,8 +351,8 @@ const EmployeeAddLead = () => {
           </Card>
 
           {/* Actions */}
-          <div className="flex gap-3 pb-8">
-            <Button type="submit" disabled={loading} className="flex-1 bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 text-white py-3">
+          <div className="sticky bottom-3 flex gap-3 pb-2">
+            <Button type="submit" disabled={loading} className="flex-1 bg-[#155C52] hover:bg-[#11463E] text-white py-3 rounded-xl">
               <Save size={18} className="mr-2" />
               {loading ? 'Submitting...' : 'Submit Lead'}
             </Button>

--- a/src/crm/pages/MobileLeadDetails.jsx
+++ b/src/crm/pages/MobileLeadDetails.jsx
@@ -62,7 +62,7 @@ const MobileLeadDetails = () => {
       navigate(-1);
     } else {
       // Default fallback to my-leads
-      navigate('/crm/my-leads');
+      navigate('/crm/sales/my-leads');
     }
   };
 
@@ -81,7 +81,7 @@ const MobileLeadDetails = () => {
     return (
       <div className="p-8 text-center">
         <p className="text-gray-500">Lead not found</p>
-        <Button onClick={() => navigate('/crm/my-leads')} className="mt-4">
+        <Button onClick={() => navigate('/crm/sales/my-leads')} className="mt-4">
           Back to Leads
         </Button>
       </div>
@@ -153,9 +153,9 @@ const MobileLeadDetails = () => {
   const lastUpdated = lead.updatedAt || lead.updated_at;
 
   return (
-    <div className="min-h-screen bg-gray-50 pb-24">
+    <div className="min-h-screen bg-[#F6F7F9] pb-24">
       {/* Header */}
-      <div className="bg-white border-b px-4 py-3 sticky top-0 z-10">
+      <div className="bg-white/95 backdrop-blur border-b px-4 py-3 sticky top-0 z-10">
         <div className="flex items-center gap-3 max-w-5xl mx-auto">
           <button
             onClick={handleBack}
@@ -164,7 +164,7 @@ const MobileLeadDetails = () => {
             <ArrowLeft size={20} className="text-gray-600" />
           </button>
           <div className="flex-1 min-w-0">
-            <h1 className="text-base md:text-xl font-bold text-gray-900 truncate">Lead Details</h1>
+            <h1 className="text-base md:text-xl font-bold text-[#1D222C] truncate">Lead Details</h1>
           </div>
         </div>
       </div>
@@ -176,7 +176,7 @@ const MobileLeadDetails = () => {
           <div className="lg:col-span-2 space-y-3">
 
             {/* Lead Summary Card */}
-            <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4 md:p-6">
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-4 md:p-6">
               <div className="flex items-start justify-between mb-3">
                 {isEditingName ? (
                   <div className="flex gap-2 flex-1">
@@ -252,26 +252,26 @@ const MobileLeadDetails = () => {
             <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
               <Button
                 onClick={() => setIsLogCallModalOpen(true)}
-                className="h-11 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-sm font-semibold rounded-xl"
+                className="h-11 bg-[#155C52] hover:bg-[#11463E] text-sm font-semibold rounded-xl"
               >
                 <PhoneCall size={16} className="mr-1.5" />
                 Log Call
               </Button>
               <Button
                 onClick={() => navigate(`/crm/lead/${lead.id}/update`)}
-                className="h-11 bg-blue-600 hover:bg-blue-700 text-sm font-semibold rounded-xl"
+                className="h-11 bg-white border border-gray-200 text-gray-700 hover:bg-gray-50 text-sm font-semibold rounded-xl"
               >
                 Update
               </Button>
               <Button
                 onClick={() => navigate(`/crm/sales/site-visits?leadId=${lead.id}`)}
-                className="h-11 bg-purple-600 hover:bg-purple-700 text-sm font-semibold rounded-xl"
+                className="h-11 bg-white border border-gray-200 text-gray-700 hover:bg-gray-50 text-sm font-semibold rounded-xl"
               >
                 <MapPin size={16} className="mr-1.5" />
                 Visit
               </Button>
               <a href={`https://wa.me/91${lead.phone}`} target="_blank" rel="noopener noreferrer" className="block">
-                <Button className="w-full h-11 bg-green-500 hover:bg-green-600 text-sm font-semibold rounded-xl">
+                <Button className="w-full h-11 bg-white border border-gray-200 text-gray-700 hover:bg-gray-50 text-sm font-semibold rounded-xl">
                   <MessageSquare size={16} className="mr-1.5" />
                   WhatsApp
                 </Button>
@@ -280,7 +280,7 @@ const MobileLeadDetails = () => {
 
             {/* Additional Info */}
             {(lead.source || lead.notes) && (
-              <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4 md:p-6">
+              <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-4 md:p-6">
                 <h3 className="text-sm font-semibold text-gray-700 mb-2">Details</h3>
                 {lead.source && (
                   <div className="mb-2">
@@ -302,7 +302,7 @@ const MobileLeadDetails = () => {
           <div className="space-y-3">
 
             {/* Phone Section */}
-            <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4">
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-4">
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Contact</h3>
 
               {/* Primary Phone */}


### PR DESCRIPTION
### Motivation
- Align the employee-facing lead screens with the provided mobile design reference (visual refresh only), keeping existing behavior and data flow unchanged.

### Description
- Restyled `EmployeeAddLead.jsx` with a neutral app background, compact header, softer white cards with rounded corners, consistent green accent, and a sticky action bar to match the mockup while preserving all form fields and logic.
- Restyled `MobileLeadDetails.jsx` to use the same visual language: neutral background, rounded card containers, refined sticky header with backdrop blur, and simplified action button tones; also fixed the fallback navigation route to `/crm/sales/my-leads`.
- These are UI-only changes (CSS/class tweaks and minor element adjustments) and do not introduce new features or change business logic.

### Testing
- Ran `npm run build` to validate the production build, but the build failed in this environment due to an external npm registry 403 when fetching `vite`, so no full production artifact was produced.
- No automated unit or integration tests were changed; visual verification is recommended in a local/dev environment where dependencies can be installed and the app can be built successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5c58390083268751db7e8a2ed6a4)