### PR TITLE
Implement dynamic broker payout rules and Supabase schema

### DIFF
--- a/src/lib/brokerSupabase.js
+++ b/src/lib/brokerSupabase.js
@@ -6,7 +6,7 @@ const URL  = import.meta.env.VITE_SUPABASE_URL;
 const KEY  = import.meta.env.VITE_SUPABASE_SERVICE_ROLE_KEY || import.meta.env.VITE_SUPABASE_ANON_KEY;
 export const brokerDb = createClient(URL, KEY);
 
-// ─── Rank config (mirrors static data) ──────────────────────────────────────
+// ─── Rank config (fallback static data; can be overridden by DB rules) ─────
 export const RANKS = [
   { rank:'RANK.1',  title:'EX',               commission:5,    directMin:100,  teamQual:'100 SQYD (min 1 direct)' },
   { rank:'RANK.2',  title:'SR. EX',            commission:5.5,  directMin:0,    teamQual:'750 SQYD' },
@@ -25,17 +25,54 @@ export const RANKS = [
   { rank:'RANK.15', title:'President',          commission:12,   directMin:0,    teamQual:'3 Vice President' },
 ];
 
-export const getRankConfig = (rankStr) =>
-  RANKS.find(r => r.rank === rankStr) || RANKS[0];
+let rankRulesCache = null;
+let rankRulesCacheTime = 0;
+const RANK_RULES_CACHE_MS = 5 * 60 * 1000;
 
-// Level commission differential — parent earns difference
-// e.g. RANK.2 parent (5.5%) on RANK.1 sale (5%) earns 0.5% differential
-export const getLevelCommission = (parentRank, childRank, saleAmount) => {
-  const pr = getRankConfig(parentRank);
-  const cr = getRankConfig(childRank);
-  const diff = Math.max(0, pr.commission - cr.commission);
-  return (diff / 100) * saleAmount;
-};
+function mapRankRowsToConfig(rows = []) {
+  return rows.map(r => ({
+    rank: r.rank,
+    title: r.title,
+    commission: Number(r.commission_percent || 0),
+    directMin: Number(r.direct_min_sqyd || 0),
+    teamQual: r.team_qualification || '-',
+    levelDepth: Number(r.level_depth || 20),
+  }));
+}
+
+export async function fetchRankConfigs() {
+  const now = Date.now();
+  if (rankRulesCache && now - rankRulesCacheTime < RANK_RULES_CACHE_MS) return rankRulesCache;
+
+  const { data, error } = await brokerDb.from('broker_rank_rules')
+    .select('rank,title,commission_percent,direct_min_sqyd,team_qualification,level_depth')
+    .eq('is_active', true)
+    .order('sort_order', { ascending: true });
+
+  if (error || !data?.length) {
+    rankRulesCache = RANKS;
+    rankRulesCacheTime = now;
+    return rankRulesCache;
+  }
+
+  rankRulesCache = mapRankRowsToConfig(data);
+  rankRulesCacheTime = now;
+  return rankRulesCache;
+}
+
+export async function getRankConfig(rankStr) {
+  const rules = await fetchRankConfigs();
+  return rules.find(r => r.rank === rankStr) || rules[0] || RANKS[0];
+}
+
+export async function getLevelCommission(parentRank, childRank, saleAmount) {
+  const [pr, cr] = await Promise.all([
+    getRankConfig(parentRank),
+    getRankConfig(childRank),
+  ]);
+  const diff = Math.max(0, Number(pr.commission || 0) - Number(cr.commission || 0));
+  return (diff / 100) * Number(saleAmount || 0);
+}
 
 // ─── Auth ─────────────────────────────────────────────────────────────────
 const SESSION_KEY = 'broker_session_v2';
@@ -59,8 +96,11 @@ async function sha256(str) {
   return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2,'0')).join('');
 }
 
-// Generate unique broker ID: FNB-XXXXX
+// Generate unique broker ID from DB function if available
 async function generateBrokerId() {
+  const { data, error } = await brokerDb.rpc('next_broker_code');
+  if (!error && data) return data;
+
   const { count } = await brokerDb.from('brokers').select('*', { count: 'exact', head: true });
   const num = String((count || 0) + 1).padStart(5, '0');
   return `FNB-${num}`;
@@ -68,9 +108,18 @@ async function generateBrokerId() {
 
 // Generate 8-char referral code
 function generateReferralCode(name) {
-  const base = name.replace(/\s+/g,'').toUpperCase().slice(0,4);
+  const base = name.replace(/\s+/g,'').toUpperCase().slice(0,4) || 'FNBR';
   const rand = Math.random().toString(36).substring(2,6).toUpperCase();
   return `${base}${rand}`;
+}
+
+async function generateUniqueReferralCode(name) {
+  for (let i = 0; i < 5; i++) {
+    const code = generateReferralCode(name);
+    const { data } = await brokerDb.from('brokers').select('id').eq('referral_code', code).maybeSingle();
+    if (!data) return code;
+  }
+  return `${(name || 'FNBR').replace(/\s+/g,'').toUpperCase().slice(0,4)}${Date.now().toString(36).slice(-4).toUpperCase()}`;
 }
 
 // ─── Register ──────────────────────────────────────────────────────────────
@@ -90,7 +139,7 @@ export async function brokerRegister({ name, email, phone, password, referralCod
 
   const hash      = await sha256(password);
   const brokerId  = await generateBrokerId();
-  const myCode    = generateReferralCode(name);
+  const myCode    = await generateUniqueReferralCode(name);
 
   const { data, error } = await brokerDb.from('brokers').insert({
     broker_id: brokerId,
@@ -170,7 +219,7 @@ export async function fetchAllSales() {
   return data || [];
 }
 
-// ─── Admin: add sale + auto-compute payouts ─────────────────────────────────
+// ─── Admin: add sale + auto-compute payouts (dynamic depth) ────────────────
 export async function adminAddSale({ broker_id, project, sqyd, sale_amount, booking_date, notes }) {
   // 1. Insert sale
   const { data: sale, error } = await brokerDb.from('broker_sales').insert({
@@ -184,36 +233,40 @@ export async function adminAddSale({ broker_id, project, sqyd, sale_amount, book
 
   // 2. Direct commission for the broker
   const { data: broker } = await brokerDb.from('brokers').select('rank, parent_id').eq('id', broker_id).single();
-  const rankCfg = getRankConfig(broker.rank);
-  const directAmt = (rankCfg.commission / 100) * Number(sale_amount);
+  const rankCfg = await getRankConfig(broker.rank);
+  const directAmt = (Number(rankCfg.commission || 0) / 100) * Number(sale_amount);
 
   await brokerDb.from('broker_payouts').insert({
     broker_id, sale_id: sale.id,
     amount: directAmt,
     payout_type: 'direct_commission',
     level: 0, status: 'pending',
+    notes: `Direct ${rankCfg.commission}%`,
   });
 
-  // 3. Level (upline) differential commission — walk up 3 levels
+  // 3. Level (upline) differential commission — dynamic depth from rank rule
   let childRank = broker.rank;
   let parentId  = broker.parent_id;
   let level     = 1;
+  const maxDepth = Math.max(1, Number(rankCfg.levelDepth || 20));
 
-  while (parentId && level <= 3) {
+  while (parentId && level <= maxDepth) {
     const { data: parent } = await brokerDb.from('brokers')
-      .select('rank, parent_id').eq('id', parentId).single();
+      .select('id, rank, parent_id').eq('id', parentId).single();
     if (!parent) break;
 
-    const levelAmt = getLevelCommission(parent.rank, childRank, Number(sale_amount));
+    const levelAmt = await getLevelCommission(parent.rank, childRank, Number(sale_amount));
     if (levelAmt > 0) {
       await brokerDb.from('broker_payouts').insert({
-        broker_id: parentId, sale_id: sale.id,
+        broker_id: parent.id,
+        sale_id: sale.id,
         amount: levelAmt,
         payout_type: 'level_commission',
         level, status: 'pending',
         notes: `L${level} differential from ${broker_id}`,
       });
     }
+
     childRank = parent.rank;
     parentId  = parent.parent_id;
     level++;

--- a/src/pages/BrokerLoginPage.jsx
+++ b/src/pages/BrokerLoginPage.jsx
@@ -43,6 +43,14 @@ const BrokerLoginPage = () => {
           <h2 className="text-xl font-bold text-[#0F3A5F] mb-1">Welcome back</h2>
           <p className="text-sm text-gray-500 mb-6">Sign in with your registered email</p>
 
+          <div className="mb-5 rounded-2xl bg-[#0F3A5F]/5 border border-[#0F3A5F]/10 px-4 py-3">
+            <p className="text-xs font-bold text-[#0F3A5F]">Dynamic Payout Network Enabled</p>
+            <p className="text-xs text-gray-600 mt-1">
+              Every broker gets a unique referral ID. New brokers can sign up through your referral link,
+              and level commission is auto-calculated for upline brokers.
+            </p>
+          </div>
+
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label className="block text-sm font-semibold text-gray-700 mb-1.5">Email address</label>

--- a/src/pages/BrokerPayoutPortalPage.jsx
+++ b/src/pages/BrokerPayoutPortalPage.jsx
@@ -4,7 +4,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import {
   getBrokerSession, brokerLogout,
   fetchBroker, fetchBrokerSales, fetchBrokerPayouts, fetchDownline,
-  calcTotals, RANKS, getRankConfig
+  calcTotals, RANKS, fetchRankConfigs
 } from '@/lib/brokerSupabase';
 import {
   LogOut, Copy, CheckCheck, TrendingUp, Users, Wallet,
@@ -29,8 +29,8 @@ const Stat = ({ label, value, sub, icon: Icon, accent }) => (
 );
 
 // ── Rank badge ──────────────────────────────────────────────────────────────
-const RankBadge = ({ rank }) => {
-  const cfg = getRankConfig(rank);
+const RankBadge = ({ rank, rules }) => {
+  const cfg = (rules || []).find(r => r.rank === rank) || rules?.[0] || RANKS[0];
   return (
     <span className="inline-flex items-center gap-1.5 bg-[#D4AF37]/10 text-[#9a7720] text-xs font-bold px-3 py-1 rounded-full">
       <BadgeCheck size={11}/>{cfg.rank} · {cfg.title} · {cfg.commission}%
@@ -47,20 +47,23 @@ const BrokerPayoutPortalPage = () => {
   const [payouts,  setPayouts]  = useState([]);
   const [downline, setDownline] = useState([]);
   const [tab,      setTab]      = useState('overview');
+  const [rankRules, setRankRules] = useState(RANKS);
   const [loading,  setLoading]  = useState(true);
   const [copied,   setCopied]   = useState(false);
 
   const load = async () => {
     if (!session) return;
     setLoading(true);
-    const [b, s, p, d] = await Promise.all([
+    const [b, s, p, d, rr] = await Promise.all([
       fetchBroker(session.id),
       fetchBrokerSales(session.id),
       fetchBrokerPayouts(session.id),
       fetchDownline(session.id),
+      fetchRankConfigs(),
     ]);
     if (b) setBroker(b);
     setSales(s); setPayouts(p); setDownline(d);
+    if (rr?.length) setRankRules(rr);
     setLoading(false);
   };
 
@@ -99,7 +102,7 @@ const BrokerPayoutPortalPage = () => {
               </div>
               <h1 className="text-2xl font-black text-white">{broker?.name}</h1>
               <p className="text-sm text-white/60 mt-0.5">{broker?.broker_id} · {broker?.email}</p>
-              <div className="mt-2"><RankBadge rank={broker?.rank} /></div>
+              <div className="mt-2"><RankBadge rank={broker?.rank} rules={rankRules} /></div>
             </div>
             <button onClick={handleLogout} className="flex items-center gap-1.5 text-xs text-white/60 hover:text-white transition">
               <LogOut size={14}/> Logout
@@ -273,7 +276,7 @@ const BrokerPayoutPortalPage = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {RANKS.map((r,i) => (
+                  {rankRules.map((r,i) => (
                     <tr key={r.rank} className={`border-t ${ broker?.rank === r.rank ? 'bg-[#D4AF37]/10' : i%2===0?'bg-white':'bg-gray-50/50' }`}>
                       <td className="px-3 py-2.5 font-bold text-[#0F3A5F]">{r.rank}</td>
                       <td className="px-3 py-2.5">{r.title}</td>

--- a/supabase/migrations/20260415_broker_dynamic_payout_rules.sql
+++ b/supabase/migrations/20260415_broker_dynamic_payout_rules.sql
@@ -1,0 +1,114 @@
+-- ============================================================
+-- FANBE BROKER SYSTEM: Dynamic payout rules + safe broker code
+-- ============================================================
+
+-- 1) Ensure pgcrypto exists (for gen_random_uuid in some projects)
+create extension if not exists pgcrypto;
+
+-- 2) Sequence-backed broker code to avoid race conditions
+create sequence if not exists public.broker_code_seq start 1;
+
+create or replace function public.next_broker_code()
+returns text
+language plpgsql
+security definer
+as $$
+declare
+  next_num bigint;
+begin
+  next_num := nextval('public.broker_code_seq');
+  return 'FNB-' || lpad(next_num::text, 5, '0');
+end;
+$$;
+
+-- Keep sequence in sync with existing broker_id values (FNB-00001 style)
+select setval(
+  'public.broker_code_seq',
+  greatest(
+    coalesce((
+      select max(nullif(regexp_replace(broker_id, '^FNB-', ''), '')::bigint)
+      from public.brokers
+      where broker_id ~ '^FNB-[0-9]+$'
+    ), 0),
+    1
+  ),
+  true
+);
+
+-- 3) Dynamic rank rules table (used by frontend logic)
+create table if not exists public.broker_rank_rules (
+  id                  uuid primary key default gen_random_uuid(),
+  rank                text unique not null,
+  title               text not null,
+  commission_percent  numeric(5,2) not null,
+  direct_min_sqyd     numeric(12,2) default 0,
+  team_qualification  text,
+  level_depth         integer not null default 20,
+  sort_order          integer not null,
+  is_active           boolean not null default true,
+  created_at          timestamptz not null default now(),
+  updated_at          timestamptz not null default now()
+);
+
+create index if not exists idx_broker_rank_rules_active_sort
+  on public.broker_rank_rules(is_active, sort_order);
+
+-- 4) Seed rank rules from the current static plan (idempotent)
+insert into public.broker_rank_rules (rank, title, commission_percent, direct_min_sqyd, team_qualification, level_depth, sort_order)
+values
+  ('RANK.1',  'EX',               5.00, 100, '100 SQYD (min 1 direct)', 20, 1),
+  ('RANK.2',  'SR. EX',            5.50,   0, '750 SQYD',                20, 2),
+  ('RANK.3',  'Sales Officer',      6.00,   0, '1250 SQYD',               20, 3),
+  ('RANK.4',  'SR S.O',             6.50,   0, '2000 SQYD',               20, 4),
+  ('RANK.5',  'Team Manager',       7.00,   0, '3 SR S.O',                20, 5),
+  ('RANK.6',  'SR T.M',             7.50,   0, '3 T.M',                   20, 6),
+  ('RANK.7',  'Asst. Sales Mgr',    8.00,   0, '3 SR T.M',                20, 7),
+  ('RANK.8',  'Sales Mgr',          8.50,   0, '3 Asst. Sales Mgr',       20, 8),
+  ('RANK.9',  'Sr. S.M',            9.00,   0, '3 Sales Mgr',             20, 9),
+  ('RANK.10', 'Asst. Gen. Mgr',     9.50,   0, '3 Sr. S.M',               20,10),
+  ('RANK.11', 'G.M',               10.00,   0, '3 Asst. Gen. Mgr',        20,11),
+  ('RANK.12', 'Sr. G.M',           10.50,   0, '3 G.M',                   20,12),
+  ('RANK.13', 'Zonal Mgr',         11.00,   0, '3 Sr. G.M',               20,13),
+  ('RANK.14', 'Vice President',    11.50,   0, '3 Zonal Mgr',             20,14),
+  ('RANK.15', 'President',         12.00,   0, '3 Vice President',        20,15)
+on conflict (rank)
+do update set
+  title = excluded.title,
+  commission_percent = excluded.commission_percent,
+  direct_min_sqyd = excluded.direct_min_sqyd,
+  team_qualification = excluded.team_qualification,
+  level_depth = excluded.level_depth,
+  sort_order = excluded.sort_order,
+  is_active = true,
+  updated_at = now();
+
+-- 5) Optional rule table for bonanza / team rewards (future-ready)
+create table if not exists public.broker_reward_rules (
+  id            uuid primary key default gen_random_uuid(),
+  reward_type   text not null check (reward_type in ('direct_bonanza', 'team_reward')),
+  threshold     numeric(14,2) not null,
+  threshold_uom text not null default 'sqyd',
+  reward_name   text not null,
+  sort_order    integer not null default 1,
+  is_active     boolean not null default true,
+  created_at    timestamptz not null default now()
+);
+
+create index if not exists idx_broker_reward_rules_type_active_sort
+  on public.broker_reward_rules(reward_type, is_active, sort_order);
+
+-- 6) Trigger function to maintain updated_at
+create or replace function public.set_updated_at_now()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_broker_rank_rules_updated_at on public.broker_rank_rules;
+create trigger trg_broker_rank_rules_updated_at
+before update on public.broker_rank_rules
+for each row execute function public.set_updated_at_now();


### PR DESCRIPTION
### Motivation
- Replace the static, page-only payout system with a dynamic, DB-driven payout engine so brokers can sign up with referral codes, receive unique IDs, and upline commissions are computed automatically. 
- Make payout commission rates and level depth configurable from the database to avoid code changes for business rule updates.

### Description
- Load rank/commission rules from a new `broker_rank_rules` table with a cached fallback to the in-code `RANKS` array and expose `fetchRankConfigs`, `getRankConfig` and `getLevelCommission` in `src/lib/brokerSupabase.js` so commission logic is dynamic. 
- Make registration safer by attempting `next_broker_code()` RPC (sequence-backed) for broker IDs and adding a retrying `generateUniqueReferralCode` to avoid referral-code collisions. 
- Adapt payout computation to use dynamic rules and configurable depth in `adminAddSale`, and persist direct and level payouts to `broker_payouts` (notes added for direct commission). 
- UI updates: add a short informational notice on `src/pages/BrokerLoginPage.jsx` and update `src/pages/BrokerPayoutPortalPage.jsx` so the dashboard reads and displays rules from the DB (rank badge and income plan table). 
- Add a Supabase migration `supabase/migrations/20260415_broker_dynamic_payout_rules.sql` which creates `broker_code_seq` + `next_broker_code()`, `broker_rank_rules`, `broker_reward_rules`, seeds the rank rows, and provides triggers to maintain timestamps.

### Testing
- Attempted a production build with `npm run build` to validate integration, which failed in this environment due to npm registry access returning `E403 Forbidden` while fetching `vite`, so runtime build validation could not be completed here. 
- No automated unit tests were executed in this environment beyond the build attempt due to registry/network restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df6a8da93c832682513bdab1b90e61)