### PR TITLE
fix: exclude archived leads from employee lead list and useMyLeads hook

### DIFF
--- a/src/crm/hooks/useMyLeads.js
+++ b/src/crm/hooks/useMyLeads.js
@@ -126,6 +126,7 @@ export const useMyLeads = (userId) => {
         .from('leads')
         .select(LEAD_COLUMNS)
         .eq('assigned_to', userId)
+        .eq('is_archived', false)
         .order('created_at', { ascending: false });
 
       if (error) { console.error('[useMyLeads] leads fetch error:', error.message); return; }

--- a/src/crm/pages/EmployeeLeadList.jsx
+++ b/src/crm/pages/EmployeeLeadList.jsx
@@ -512,6 +512,7 @@ const EmployeeLeadList = () => {
       .from('leads')
       .select('id,name,phone,project,status,budget,assigned_to,follow_up_date,updated_at,created_at,last_note')
       .eq('assigned_to', userId)
+      .eq('is_archived', false)
       .order('updated_at', { ascending: false })
       .range(fromIndex, fromIndex + PAGE_SIZE - 1);
 
@@ -570,6 +571,7 @@ const EmployeeLeadList = () => {
         .from('leads')
         .select('id,name,phone,project,status,budget,assigned_to,follow_up_date,updated_at,created_at,last_note')
         .eq('assigned_to', userId)
+        .eq('is_archived', false)
         .order('updated_at', { ascending: false })
         .range(0, PAGE_SIZE - 1);
 
@@ -602,6 +604,7 @@ const EmployeeLeadList = () => {
         .from('leads')
         .select('id,name,phone,project,status,budget,assigned_to,follow_up_date,updated_at,created_at,last_note')
         .eq('assigned_to', userId)
+        .eq('is_archived', false)
         .order('updated_at', { ascending: false })
         .range(fromIndex, fromIndex + PAGE_SIZE - 1);
 


### PR DESCRIPTION
### Motivation
- Archived leads were leaking into employee-facing lead lists and stats because queries did not filter out rows where `is_archived` is true.

### Description
- Added `.eq('is_archived', false)` immediately after `.eq('assigned_to', userId)` in `buildQuery`, `fetchFirstPage`, and `fetchNextPage` in `src/crm/pages/EmployeeLeadList.jsx`.
- Added `.eq('is_archived', false)` after `.eq('assigned_to', userId)` in the `fetchLeads` query inside `src/crm/hooks/useMyLeads.js`.
- No other logic, styling, or files were changed.

### Testing
- Confirmed the new `is_archived` filter appears in all modified locations via a code search; the check succeeded.
- Inspected the file diff to verify only the intended insertions were made and no other changes occurred; the inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08e32846483268ce3d3e05255cc83)