### PR TITLE
Improve telecaller workflow: inline actions, follow-up notifications, smarter quick note

### DIFF
--- a/src/components/crm/SmartQuickNote.tsx
+++ b/src/components/crm/SmartQuickNote.tsx
@@ -133,6 +133,15 @@ export function SmartQuickNote({
         )}
       </div>
 
+      {(intel.urgency !== 'low' || intel.budgetLakhs !== null) && (
+        <div className="flex flex-wrap gap-2 text-xs">
+          {intel.urgency === 'high' && <span className="px-2 py-0.5 rounded-full bg-rose-100 text-rose-700">🔥 High urgency</span>}
+          {intel.urgency === 'medium' && <span className="px-2 py-0.5 rounded-full bg-amber-100 text-amber-700">⚡ Medium urgency</span>}
+          {intel.budgetLakhs !== null && <span className="px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700">💰 ₹{intel.budgetLakhs}L budget</span>}
+          {intel.needsDecisionMaker && <span className="px-2 py-0.5 rounded-full bg-violet-100 text-violet-700">👥 Loop in decision-maker</span>}
+        </div>
+      )}
+
       {intel.warnings.length > 0 && (
         <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 space-y-1">
           {intel.warnings.map((w, i) => (

--- a/src/lib/quickNoteIntel.ts
+++ b/src/lib/quickNoteIntel.ts
@@ -14,6 +14,9 @@ export interface SmartNoteResult {
   requiresLostReason: boolean               // true when tagged not_interested
   missingNextAction: boolean                // true if no follow-up & no terminal status
   warnings: string[]
+  urgency: 'low' | 'medium' | 'high'        // how hot is this lead right now
+  budgetLakhs: number | null                // parsed budget figure in INR lakhs
+  needsDecisionMaker: boolean               // talking to non-decision-maker
 }
 
 const TAG_KEYWORDS: Record<LeadTag, RegExp> = {
@@ -49,6 +52,29 @@ const TIME_PATTERNS: Array<[RegExp, (m: RegExpMatchArray, now: Date) => Date | n
   // "next month"
   [/next month/i, (_m, now) => {
     const d = new Date(now); d.setMonth(d.getMonth() + 1); d.setHours(11, 0, 0, 0); return d
+  }],
+  // "this evening" / "tonight"
+  [/\b(this evening|tonight)\b/i, (_m, now) => {
+    const d = new Date(now); d.setHours(19, 0, 0, 0); return d
+  }],
+  // "tomorrow morning" / "tomorrow evening"
+  [/tomorrow\s+(morning|afternoon|evening|night)/i, (m, now) => {
+    const d = new Date(now); d.setDate(d.getDate() + 1)
+    const map: Record<string, number> = { morning: 10, afternoon: 14, evening: 18, night: 20 }
+    d.setHours(map[m[1].toLowerCase()] ?? 11, 0, 0, 0); return d
+  }],
+  // "after lunch"
+  [/after\s+lunch/i, (_m, now) => {
+    const d = new Date(now); d.setHours(15, 0, 0, 0)
+    if (d.getTime() < now.getTime()) d.setDate(d.getDate() + 1)
+    return d
+  }],
+  // "monday" / "next monday"
+  [/\b(?:next\s+)?(mon|tue|wed|thu|fri|sat|sun)(?:day|sday|nesday|rsday|urday)?\b/i, (m, now) => {
+    const map: Record<string, number> = { sun:0, mon:1, tue:2, wed:3, thu:4, fri:5, sat:6 }
+    const target = map[m[1].slice(0,3).toLowerCase()]; if (target === undefined) return null
+    const d = new Date(now); const diff = (target - d.getDay() + 7) % 7 || 7
+    d.setDate(d.getDate() + diff); d.setHours(11, 0, 0, 0); return d
   }],
 ]
 
@@ -111,11 +137,35 @@ export function analyzeQuickNote(
   const terminal = detected.has('not_interested') || detected.has('wrong_number')
   const missingNextAction = !terminal && !suggestedFollowUp
 
+  // Budget figure: "25L", "25 lakh", "2.5 cr", "₹ 25,00,000"
+  let budgetLakhs: number | null = null
+  const lakh = t.match(/(\d+(?:\.\d+)?)\s*(l|lakh|lac)\b/i)
+  const cr   = t.match(/(\d+(?:\.\d+)?)\s*(cr|crore)\b/i)
+  const rup  = t.match(/(?:rs\.?|inr|₹)\s*([\d,]+)/i)
+  if (cr) budgetLakhs = parseFloat(cr[1]) * 100
+  else if (lakh) budgetLakhs = parseFloat(lakh[1])
+  else if (rup) {
+    const n = parseInt(rup[1].replace(/,/g, ''), 10)
+    if (!isNaN(n) && n >= 100000) budgetLakhs = +(n / 100000).toFixed(2)
+  }
+
+  const needsDecisionMaker = /\b(wife|husband|father|mother|family|brother|partner|spouse|will (ask|discuss|check) (with|my))\b/i.test(t)
+    && !/\b(i am|i'?m) the (owner|decision)\b/i.test(t)
+
   const warnings: string[] = []
   if (missingNextAction) warnings.push('No follow-up set — this lead could be forgotten.')
   if (requiresLostReason) warnings.push('Marked Not Interested — capture a reason before saving.')
-  if (detected.has('budget_issue') && !/\b\d/.test(t))
+  if (detected.has('budget_issue') && budgetLakhs === null)
     warnings.push('Budget mentioned — note exact figure to match future inventory.')
+  if (needsDecisionMaker)
+    warnings.push('Decision-maker not on call — schedule a callback when both are available.')
+  if (detected.has('site_visit') && !parsed)
+    warnings.push('Site visit discussed — confirm exact date & time before saving.')
+
+  let urgency: 'low' | 'medium' | 'high' = 'low'
+  if (detected.has('interested') || detected.has('site_visit')) urgency = 'high'
+  else if (detected.has('callback_requested') || detected.has('call_later')) urgency = 'medium'
+  if (detected.has('not_interested') || detected.has('wrong_number')) urgency = 'low'
 
   return {
     suggestedTags: Array.from(detected),
@@ -124,6 +174,9 @@ export function analyzeQuickNote(
     requiresLostReason,
     missingNextAction,
     warnings,
+    urgency,
+    budgetLakhs,
+    needsDecisionMaker,
   }
 }
 

--- a/src/lib/useFollowUpNotifications.ts
+++ b/src/lib/useFollowUpNotifications.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react'
+import type { CrmLead } from '@/types'
+
+// Fires a desktop notification when a lead's next_follow_up_at becomes due.
+// Each (lead, scheduled-time) pair fires at most once per browser session.
+export function useFollowUpNotifications(leads: CrmLead[]) {
+  const fired = useRef<Set<string>>(new Set())
+  const timers = useRef<number[]>([])
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('Notification' in window)) return
+    if (Notification.permission === 'default') {
+      Notification.requestPermission().catch(() => {})
+    }
+
+    timers.current.forEach(clearTimeout)
+    timers.current = []
+
+    const now = Date.now()
+    for (const l of leads) {
+      if (!l.next_follow_up_at) continue
+      if (l.status === 'lost' || l.status === 'booked') continue
+      const due = new Date(l.next_follow_up_at).getTime()
+      const key = `${l.id}:${l.next_follow_up_at}`
+      if (fired.current.has(key)) continue
+      const delay = due - now
+      const fire = () => {
+        if (fired.current.has(key)) return
+        fired.current.add(key)
+        if (Notification.permission === 'granted') {
+          const n = new Notification(`Follow up: ${l.name}`, {
+            body: `${l.phone}${l.quick_note ? ' · ' + l.quick_note : ''}`,
+            tag: l.id,
+          })
+          n.onclick = () => { window.focus(); n.close() }
+        }
+      }
+      if (delay <= 0) fire()
+      else if (delay < 6 * 60 * 60 * 1000) {
+        timers.current.push(window.setTimeout(fire, delay))
+      }
+    }
+    return () => { timers.current.forEach(clearTimeout); timers.current = [] }
+  }, [leads])
+}

--- a/src/pages/CallCRM.tsx
+++ b/src/pages/CallCRM.tsx
@@ -6,9 +6,10 @@ import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { Badge } from '@/components/ui/Badge'
 import { SmartQuickNote, SmartQuickNoteValue } from '@/components/crm/SmartQuickNote'
-import { Phone, Search, Plus, Copy, MessageCircle, Clock } from 'lucide-react'
+import { Phone, Search, Plus, Copy, MessageCircle, Clock, StickyNote } from 'lucide-react'
 import toast from 'react-hot-toast'
 import type { CrmLead } from '@/types'
+import { useFollowUpNotifications } from '@/lib/useFollowUpNotifications'
 
 const STATUS_COLOR: Record<string, string> = {
   new:        'bg-blue-100 text-blue-700',
@@ -86,6 +87,8 @@ export default function CallCRM() {
     },
     onError: (e: any) => toast.error(e.message),
   })
+
+  useFollowUpNotifications(leads)
 
   const filtered = useMemo(() => {
     const now = Date.now()
@@ -217,12 +220,20 @@ function LeadCard({ idx, lead, onOpen }: { idx: number; lead: CrmLead; onOpen: (
           className="p-2 rounded-lg bg-gray-50 text-gray-500 hover:bg-gray-100" title="Copy phone">
           <Copy size={14}/>
         </button>
+        <a href={`https://wa.me/${lead.phone.replace(/\D/g,'')}`} target="_blank" rel="noreferrer"
+          className="p-2 rounded-lg bg-green-50 text-green-700 hover:bg-green-100" title="WhatsApp">
+          <MessageCircle size={14}/>
+        </a>
         <a href={`tel:${lead.phone}`}
           className="p-2 rounded-lg bg-emerald-50 text-emerald-700 hover:bg-emerald-100" title="Call">
           <Phone size={14}/>
         </a>
         <button onClick={onOpen}
-          className="px-3 py-1.5 rounded-lg bg-blue-600 text-white text-xs hover:bg-blue-700">
+          className="p-2 rounded-lg bg-blue-50 text-blue-700 hover:bg-blue-100" title="Quick note">
+          <StickyNote size={14}/>
+        </button>
+        <button onClick={onOpen}
+          className="px-3 py-1.5 rounded-lg bg-blue-600 text-white text-xs hover:bg-blue-700 hidden sm:inline">
           Open
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Inline WhatsApp + Quick Note buttons on each lead card on `/crm/sales/crm` so telecallers can act without opening the modal.
- Browser/desktop notifications fire automatically when a lead's `next_follow_up_at` falls due (new `useFollowUpNotifications` hook).
- Smarter Quick Note parsing: more time phrases (tonight, tomorrow morning, after lunch, weekdays), budget extraction (L / Cr / ₹), decision-maker detection, and an urgency score surfaced as chips/warnings.

## Test plan
- [ ] Visit `/crm/sales/crm`, confirm WhatsApp & sticky-note buttons appear on each card and work.
- [ ] Set a follow-up a couple of minutes in the future, keep tab open, verify desktop notification fires.
- [ ] Type a note like "interested, site visit tomorrow evening, budget 35L, will discuss with wife" and confirm urgency, budget chip, decision-maker chip, and auto follow-up appear.

https://claude.ai/code/session_01AQTG8oBTR8XR6L241sZvj3

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQTG8oBTR8XR6L241sZvj3)_