### PR TITLE
crm: rename sidebar subtitle Payout Admin -> Sales CRM

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -34,7 +34,7 @@ export function Sidebar() {
     <aside className={`relative flex flex-col bg-[#0f172a] border-r border-[#1e293b] transition-all duration-300 ${collapsed?'w-16':'w-60'} min-h-screen z-20`}>
       <div className="flex items-center gap-3 px-4 py-5 border-b border-[#1e293b]">
         <div className="w-8 h-8 rounded-lg bg-blue-600 flex items-center justify-center text-white font-bold text-sm flex-shrink-0">F</div>
-        {!collapsed&&<div><p className="text-sm font-semibold text-white">Fanbe Group</p><p className="text-xs text-slate-400">Payout Admin</p></div>}
+        {!collapsed&&<div><p className="text-sm font-semibold text-white">Fanbe Group</p><p className="text-xs text-slate-400">Sales CRM</p></div>}
       </div>
       <nav className="flex-1 overflow-y-auto py-4 scrollbar-thin">
         {NAV.map(g=>(


### PR DESCRIPTION
## Summary
- `src/components/layout/Sidebar.tsx` header showed "Payout Admin" on `fanbegroup.com/crm/...`, which is the employee CRM site. Changed subtitle to "Sales CRM".

## Note
The Brokerage section (Brokers / KYC / Payouts / Commission Rules) still exists in this sidebar — those routes belong to the separate `fanbe-payout-admin` repo. If you want them removed from the CRM sidebar, say the word and I'll strip the Brokerage group.

## Test plan
- [ ] After deploy, sidebar header on `fanbegroup.com/crm/sales/crm` shows "Fanbe Group / Sales CRM"

---
_Generated by [Claude Code](https://claude.ai/code/session_0165q6X4LgGufvxgH2xWQWQH)_