### PR TITLE
crm: remove Brokerage nav and fix tab title

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fanbe Group — Payout Admin</title>
+    <title>Fanbe Group — Sales CRM</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useNavigate } from 'react-router-dom'
-import { LayoutDashboard, Users, Building2, Map, BookOpen, CreditCard, Banknote, Settings, LogOut, ChevronLeft, ChevronRight, BarChart2, FileText, UserCheck, Layers, Phone } from 'lucide-react'
+import { LayoutDashboard, Building2, Map, BookOpen, CreditCard, Settings, LogOut, ChevronLeft, ChevronRight, BarChart2, FileText, Phone } from 'lucide-react'
 import { useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import toast from 'react-hot-toast'
@@ -14,12 +14,6 @@ const NAV = [
     {to:'/plots',icon:Map,label:'Plots'},
     {to:'/bookings',icon:BookOpen,label:'Bookings'},
     {to:'/payments',icon:CreditCard,label:'Payments'},
-  ]},
-  { group:'Brokerage', items:[
-    {to:'/brokers',icon:Users,label:'Brokers'},
-    {to:'/kyc',icon:UserCheck,label:'KYC Review'},
-    {to:'/payouts',icon:Banknote,label:'Payouts'},
-    {to:'/commission',icon:Layers,label:'Commission Rules'},
   ]},
   { group:'Reports', items:[
     {to:'/reports',icon:FileText,label:'Reports'},


### PR DESCRIPTION
## Summary
- `index.html` `<title>` changed from "Payout Admin" -> "Sales CRM"
- `Sidebar.tsx` Brokerage group removed (Brokers / KYC / Payouts / Commission Rules belong to `fanbe-payout-admin`)
- Unused icon imports (Users, Banknote, UserCheck, Layers) dropped

## Note
Brokerage `/brokers`, `/kyc`, `/payouts`, `/commission` route components may still exist in this repo. If so, they're now unreachable from the sidebar but still bundled. Want me to delete those route files and their entries in the router too?

## Test plan
- [ ] Browser tab shows "Fanbe Group — Sales CRM"
- [ ] Sidebar shows only Main + Real Estate + Reports (no Brokerage)

---
_Generated by [Claude Code](https://claude.ai/code/session_0165q6X4LgGufvxgH2xWQWQH)_