### PR TITLE
Fix CRM self-contained deployment (base=/crm/)

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,5 @@
 Options -MultiViews
 RewriteEngine On
+RewriteBase /crm/
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^ index.html [QSA,L]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 export default defineConfig({
+  base: '/crm/',
   plugins: [react()],
   resolve: { alias: { '@': path.resolve(__dirname, './src') } },
 })


### PR DESCRIPTION
## Problem\n\nThe CRM had no `base` set in `vite.config.ts`, so all compiled assets used absolute paths from the domain root (e.g. `/assets/index-XXX.js`). When a new CRM build was deployed to `/public_html/crm/`, the new `index.html` looked for assets at `fanbegroup.com/assets/` (root) — but root only had the previous build's asset files. This caused the CRM to break after every deployment, making it appear the whole website was gone.\n\n## Changes\n\n### `vite.config.ts`\n- Added `base: '/crm/'` so all compiled JS/CSS/assets are prefixed with `/crm/` and deployed self-contained inside `/public_html/crm/assets/`\n\n### `public/.htaccess`\n- Added `RewriteBase /crm/` to match the new base path so SPA routing works correctly within the `/crm/` subfolder\n\n## Result\n\n- CRM is now fully self-contained at `/crm/` — its assets live at `/crm/assets/`, not at root\n- Deploying a new CRM build no longer depends on or affects the root `/assets/` folder\n- Main website at `fanbegroup.com/` is completely isolated from CRM deployments\n- Every future push to `main` safely deploys only to `/public_html/crm/`\n\n## Test plan\n- [ ] Merge to `main` and let GitHub Actions deploy\n- [ ] Visit `fanbegroup.com/crm/` — should load CRM login\n- [ ] Visit `fanbegroup.com/` — main website should be unaffected\n- [ ] Check browser dev tools: assets should load from `fanbegroup.com/crm/assets/` not `fanbegroup.com/assets/`

---
_Generated by [Claude Code](https://claude.ai/code/session_014i2iRLK1Zmtr1LoPoxNgF9)_