### PR TITLE
fix: BrowserRouter basename + correct route paths for /crm/ deployment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,8 +33,8 @@ export default function App(){
       <Route element={<Guard><AppLayout/></Guard>}>
         <Route path="/" element={<Dashboard/>}/>
         <Route path="/analytics" element={<Analytics/>}/>
-        <Route path="/crm/sales/crm" element={<CallCRM/>}/>
-        <Route path="/crm/sales/tools" element={<PromotionMaterials/>}/>
+        <Route path="/sales/crm" element={<CallCRM/>}/>
+        <Route path="/sales/tools" element={<PromotionMaterials/>}/>
         <Route path="/projects" element={<Projects/>}/>
         <Route path="/plots" element={<Plots/>}/>
         <Route path="/bookings" element={<Bookings/>}/>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,7 +7,7 @@ const NAV = [
   { group:'Main', items:[
     {to:'/',icon:LayoutDashboard,label:'Dashboard'},
     {to:'/analytics',icon:BarChart2,label:'Analytics'},
-    {to:'/crm/sales/crm',icon:Phone,label:'Call CRM'},
+    {to:'/sales/crm',icon:Phone,label:'Call CRM'},
   ]},
   { group:'Real Estate', items:[
     {to:'/projects',icon:Building2,label:'Projects'},
@@ -16,7 +16,7 @@ const NAV = [
     {to:'/payments',icon:CreditCard,label:'Payments'},
   ]},
   { group:'Sales Tools', items:[
-    {to:'/crm/sales/tools',icon:Megaphone,label:'Promo Materials'},
+    {to:'/sales/tools',icon:Megaphone,label:'Promo Materials'},
   ]},
   { group:'Reports', items:[
     {to:'/reports',icon:FileText,label:'Reports'},

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ const qc = new QueryClient({ defaultOptions: { queries: { staleTime: 120000, ret
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <BrowserRouter>
+      <BrowserRouter basename="/crm">
         <App />
         <Toaster position="top-right" toastOptions={{ duration: 4000 }} />
       </BrowserRouter>

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "outputDirectory": "dist",
   "rewrites": [
     { "source": "/crm/assets/:path*", "destination": "/crm/assets/:path*" },
+    { "source": "/crm", "destination": "/crm/index.html" },
     { "source": "/crm/:path*", "destination": "/crm/index.html" }
-  ],
-  "cleanUrls": true
+  ]
 }


### PR DESCRIPTION
## Problem

`BrowserRouter` had no `basename`, so React Router generated absolute paths from the domain root:

- Clicking **Dashboard** → navigated to `fanbegroup.com/` (main website, not CRM)
- Clicking **Analytics** → navigated to `fanbegroup.com/analytics` (no Vercel rewrite → 404)
- **Logout / unauthenticated guard** → redirected to `fanbegroup.com/login` (no Vercel rewrite → 404)
- Directly visiting `fanbegroup.com/crm/admin/dashboard` → Vercel served `index.html` correctly, but React Router found no matching route and redirected to `fanbegroup.com/` (main website)

The Vercel rewrite only covers `/crm/*`, so any navigation that left that prefix would break.

## Fix

### `src/main.tsx`
Added `basename="/crm"` to `BrowserRouter`. All `<Link>`, `<NavLink>`, `navigate()`, and `<Navigate>` calls are now automatically scoped to `/crm/*`.

### `src/App.tsx`
Removed `/crm/` prefix from `/crm/sales/crm` and `/crm/sales/tools` routes — the basename already provides `/crm`, so the double prefix would have made them `/crm/crm/sales/crm`.

### `src/components/layout/Sidebar.tsx`
Same path fix: `/crm/sales/crm` → `/sales/crm`, `/crm/sales/tools` → `/sales/tools`.

### `vercel.json`
- Removed `cleanUrls: true` (not needed; could cause redirect loops with `.html` rewrite destinations)
- Added `{ "source": "/crm", "destination": "/crm/index.html" }` to handle the no-trailing-slash entry point

## After this fix

| URL | Behaviour |
|-----|-----------|
| `fanbegroup.com/crm/` | CRM Dashboard ✓ |
| `fanbegroup.com/crm/login` | Login page ✓ |
| `fanbegroup.com/crm/analytics` | Analytics ✓ |
| `fanbegroup.com/crm/sales/crm` | Call CRM ✓ |
| `fanbegroup.com/crm/projects` | Projects ✓ |
| Any unknown `/crm/*` path | Redirects to `/crm/` (CRM dashboard) ✓ |
| Logout / unauthenticated | Redirects to `fanbegroup.com/crm/login` ✓ |

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_