### PR TITLE
fix: Login subtitle + guard invalid Supabase env var

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 import { createClient } from '@supabase/supabase-js'
-const URL = import.meta.env.VITE_SUPABASE_URL || 'https://mfgjzkaabyltscgrkhdz.supabase.co'
-const KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1mZ2p6a2FhYnlsdHNjZ3JraGR6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzEzNDAzNjQsImV4cCI6MjA4NjkxNjM2NH0.V6uWBH72rgp0UEFdB9aT8qrG4YFYhnERWZO1t976_tM'
-export const supabase = createClient(URL, KEY)
+
+const FALLBACK_URL = 'https://mfgjzkaabyltscgrkhdz.supabase.co'
+const FALLBACK_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1mZ2p6a2FhYnlsdHNjZ3JraGR6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzEzNDAzNjQsImV4cCI6MjA4NjkxNjM2NH0.V6uWBH72rgp0UEFdB9aT8qrG4YFYhnERWZO1t976_tM'
+
+const envUrl = import.meta.env.VITE_SUPABASE_URL
+const envKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+const SUPABASE_URL = (typeof envUrl === 'string' && envUrl.startsWith('https://')) ? envUrl : FALLBACK_URL
+const SUPABASE_KEY = (typeof envKey === 'string' && envKey.length > 50) ? envKey : FALLBACK_KEY
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -28,7 +28,7 @@ export default function Login() {
         <div className="text-center mb-8">
           <div className="w-14 h-14 rounded-2xl bg-blue-600 flex items-center justify-center text-white font-bold text-2xl mx-auto mb-4">F</div>
           <h1 className="text-2xl font-bold text-gray-900">Fanbe Group</h1>
-          <p className="text-gray-500 text-sm mt-1">Payout Admin Portal</p>
+          <p className="text-gray-500 text-sm mt-1">Employee Sales CRM</p>
         </div>
         <form onSubmit={handleLogin} className="space-y-4">
           <div>


### PR DESCRIPTION
## Problems fixed\n\n### 1. Login page said \"Payout Admin Portal\"\n`src/pages/Login.tsx` subtitle was copy-pasted from the broker payout admin. Changed to **\"Employee Sales CRM\"** so employees know they are on the right app.\n\n### 2. `TypeError: Failed to execute 'fetch' on 'Window': Invalid value`\n`supabase.ts` used `import.meta.env.VITE_SUPABASE_URL || fallback`. If Vercel has that env var set to a non-empty invalid string (e.g. `\"undefined\"`, a wrong host, or stale placeholder), the `||` check passes the bad value through and Supabase calls `fetch()` with an invalid URL.\n\nFixed by validating the env var before use:\n```ts\nconst SUPABASE_URL = (typeof envUrl === 'string' && envUrl.startsWith('https://')) ? envUrl : FALLBACK_URL\nconst SUPABASE_KEY = (typeof envKey === 'string' && envKey.length > 50) ? envKey : FALLBACK_KEY\n```\nNow any bad/missing env var silently falls back to the hardcoded credentials.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_