### PR TITLE
fix: hardcode Supabase credentials to eliminate fetch TypeError

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { supabase } from '@/lib/supabase'
 import toast from 'react-hot-toast'
 const NAV = [
   { group:'Main', items:[
-    {to:'/',icon:LayoutDashboard,label:'Dashboard'},
+    {to:'/',icon:LayoutDashboard,label:'rashboard'},
     {to:'/analytics',icon:BarChart2,label:'Analytics'},
     {to:'/sales/crm',icon:Phone,label:'Call CRM'},
   ]},

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,13 +1,10 @@
-/// <reference types="vite/client" />
 import { createClient } from '@supabase/supabase-js'
 
-const FALLBACK_URL = 'https://mfgjzkaabyltscgrkhdz.supabase.co'
-const FALLBACK_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1mZ2p6a2FhYnlsdHNjZ3JraGR6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzEzNDAzNjQsImV4cCI6MjA4NjkxNjM2NH0.V6uWBH72rgp0UEFdB9aT8qrG4YFYhnERWZO1t976_tM'
+// Credentials are hardcoded — same Supabase project as the admin CRM.
+// Env vars are NOT used: a stale/wrong VITE_SUPABASE_URL in Vercel caused
+// `fetch()` to throw "Invalid value" before any network request was made.
+const SUPABASE_URL = 'https://mfgjzkaabyltscgrkhdz.supabase.co'
+const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1mZ2p6a2FhYnlsdHNjZ3JraGR6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzEzNDAzNjQsImV4cCI6MjA4NjkxNjM2NH0.V6uWBH72rgp0UEFdB9aT8qrG4YFYhnERWZO1t976_tM'
 
-const envUrl = import.meta.env.VITE_SUPABASE_URL
-const envKey = import.meta.env.VITE_SUPABASE_ANON_KEY
-
-const SUPABASE_URL = (typeof envUrl === 'string' && envUrl.startsWith('https://')) ? envUrl : FALLBACK_URL
-const SUPABASE_KEY = (typeof envKey === 'string' && envKey.length > 50) ? envKey : FALLBACK_KEY
-
+console.log('[Sales CRM] Supabase:', SUPABASE_URL)
 export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)


### PR DESCRIPTION
## Problem\n\n`fanbegroup.com/crm/login` throws `TypeError: Failed to execute 'fetch' on 'Window': Invalid value` on every sign-in attempt. No network request is even made, meaning `fetch()` is called with an invalid argument before it hits the network.\n\nRoot cause: Vercel has a `VITE_SUPABASE_URL` environment variable set to an invalid value. Vite inlines env vars at build time, so the bad value ends up in the bundle. The previous `|| fallback` and `startsWith('https://')` guards were not enough — the env var was a truthy string that passed validation but was still an invalid URL for the Supabase fetch call.\n\n## Fix\n\nRemoved all env var logic from `src/lib/supabase.ts`. Credentials are now hardcoded — the same approach used by the pre-built admin CRM at `fanbegroup.com/`, which connects to the same Supabase project without issues.\n\nAlso added `console.log('[Sales CRM] Supabase:', SUPABASE_URL)` so the user can confirm in DevTools that the correct URL is loading."

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_