### PR TITLE
fix: serve full admin CRM at /crm/* routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,7 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/crm/assets/:path*", "destination": "/crm/assets/:path*" },
-    { "source": "/crm", "destination": "/crm/index.html" },
-    { "source": "/crm/:path*", "destination": "/crm/index.html" }
+    { "source": "/crm", "destination": "/index.html" },
+    { "source": "/crm/:path*", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## What changed

`vercel.json` — changed `/crm/*` rewrite from `→ /crm/index.html` (Sales CRM) to `→ /index.html` (pre-built admin CRM).

## Before
```
/crm/login        → dist/crm/index.html  (simplified Sales CRM)
/crm/admin/*      → dist/crm/index.html  (wrong app, Sales CRM)
```

## After
```
/crm/login        → dist/index.html  (full admin CRM)
/crm/admin/*      → dist/index.html  (full admin CRM ✓)
```

The pre-built admin CRM in `dist/index.html` has all the features shown in the Super Admin Dashboard — Leads Management, Employee Management, Sub Admin Management, HR Manager Setup, etc. Its internal React Router already handles `/crm/admin/*` routes, so refreshing at `/crm/admin/dashboard` will now load the correct app.

Also includes the sidebar test label change (`rashboard`) from the previous commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_