### PR TITLE
fix: change Dashboard → Control in admin CRM sidebar (all roles)

### DIFF
--- a/scripts/copy-main-website.mjs
+++ b/scripts/copy-main-website.mjs
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, statSync, copyFileSync } from 'fs'
+import { existsSync, mkdirSync, readdirSync, statSync, copyFileSync, readFileSync, writeFileSync } from 'fs'
 import path from 'path'
 
 const SRC = 'main-website'
@@ -25,3 +25,21 @@ function copyRecursive(src, dest) {
 
 copyRecursive(SRC, DEST)
 console.log('✅ Main website files copied into dist/')
+
+// Patch sidebar nav labels in the compiled admin CRM bundle
+const assetsDir = path.join(DEST, 'assets')
+if (existsSync(assetsDir)) {
+  for (const file of readdirSync(assetsDir)) {
+    if (!file.endsWith('.js')) continue
+    const filePath = path.join(assetsDir, file)
+    let content = readFileSync(filePath, 'utf8')
+    const patched = content.replaceAll(
+      'label:"Dashboard",path:"/crm/admin/dashboard"',
+      'label:"Control",path:"/crm/admin/dashboard"'
+    )
+    if (patched !== content) {
+      writeFileSync(filePath, patched, 'utf8')
+      console.log(`🔧 Patched sidebar label: Dashboard → Control in ${file}`)
+    }
+  }
+}


### PR DESCRIPTION
## What changed

`scripts/copy-main-website.mjs` — after copying the pre-built admin CRM files to `dist/`, the script now patches the compiled JS bundle to replace `label:"Dashboard"` with `label:"Control"` for the `/crm/admin/dashboard` nav item.

## Why this approach

The admin CRM is a pre-built binary (1.2MB minified JS). The patch targets the exact string `label:"Dashboard",path:"/crm/admin/dashboard"` which appears in the SUPER_ADMIN, SUB_ADMIN, and MANAGER nav configs — all roles that see this sidebar item. The replacement is specific enough that it does NOT affect:
- `"HR Dashboard"` (HR Manager nav item)
- `"Super Admin Dashboard"` (page heading)  
- `"Sales Dashboard"` (Employee role title)
- Tab/overview config (`M={overview:"Dashboard",...}`)

This runs at Vercel build time, so any future rebuild automatically applies the patch without touching the committed binary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_