### PR TITLE
feat: smart telecaller Sales CRM at /crm/sales/* — notifications, smart notes, mobile buttons

### DIFF
--- a/scripts/copy-main-website.mjs
+++ b/scripts/copy-main-website.mjs
@@ -26,7 +26,7 @@ function copyRecursive(src, dest) {
 copyRecursive(SRC, DEST)
 console.log('✅ Main website files copied into dist/')
 
-// Patch sidebar nav labels in the compiled admin CRM bundle
+// Patch 1: sidebar nav labels in the compiled admin CRM bundle
 const assetsDir = path.join(DEST, 'assets')
 if (existsSync(assetsDir)) {
   for (const file of readdirSync(assetsDir)) {
@@ -42,4 +42,29 @@ if (existsSync(assetsDir)) {
       console.log(`🔧 Patched sidebar label: Dashboard → Control in ${file}`)
     }
   }
+}
+
+// Patch 2: inject navigation interceptor into dist/index.html so that
+// clicking "Call CRM" (or any /crm/sales/* link) inside the admin CRM SPA
+// triggers a full page reload — this hands control to the Vite-built
+// Sales CRM which has smart notes and browser notifications.
+const indexPath = path.join(DEST, 'index.html')
+if (existsSync(indexPath)) {
+  let html = readFileSync(indexPath, 'utf8')
+  const interceptScript = `<script>
+(function(){
+  var _push = history.pushState.bind(history);
+  var _replace = history.replaceState.bind(history);
+  function intercept(url) {
+    if (!url) return false;
+    try { var p = new URL(String(url), location.href).pathname; if (p.startsWith('/crm/sales/')) { location.href = p; return true; } } catch(e) {}
+    return false;
+  }
+  history.pushState = function(s,t,url){ if(intercept(url)) return; return _push(s,t,url); };
+  history.replaceState = function(s,t,url){ if(intercept(url)) return; return _replace(s,t,url); };
+})();
+</script>`
+  html = html.replace('</head>', interceptScript + '\n</head>')
+  writeFileSync(indexPath, html, 'utf8')
+  console.log('🔧 Injected /crm/sales/* navigation interceptor into dist/index.html')
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,9 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [
+    { "source": "/crm/assets/:path*", "destination": "/crm/assets/:path*" },
+    { "source": "/crm/sales/:path*", "destination": "/crm/index.html" },
+    { "source": "/crm/sales", "destination": "/crm/index.html" },
     { "source": "/crm", "destination": "/index.html" },
     { "source": "/crm/:path*", "destination": "/index.html" }
   ]


### PR DESCRIPTION
## What this does

Routes `/crm/sales/*` to the **Vite-built Sales CRM** (source in `src/`) instead of the pre-built admin CRM binary. This unlocks three features the telecaller workflow needs:

### 1. Smart Quick Note (`src/lib/quickNoteIntel.ts` + `SmartQuickNote.tsx`)
- **Auto-detects intent** from free text: "interested", "budget issue", "call later", "site visit", "switched off", "not interested", etc.
- **Parses time expressions**: "tomorrow 5pm", "in 2 hours", "next week", "after lunch", "Monday" → auto-fills follow-up datetime
- **Extracts budget figures**: "25L", "2.5 cr", "₹25,00,000" → shows 💰 ₹25L badge
- **Detects missing decision-maker**: "will ask wife / husband" → warns 👥 Loop in decision-maker
- **Urgency scoring**: 🔥 High / ⚡ Medium shown as badges
- **Blocks save** if no follow-up is set for non-terminal leads (so no lead is ever forgotten)
- **Lost reason required** when tagged "Not Interested"

### 2. Automatic browser notifications (`src/lib/useFollowUpNotifications.ts`)
- Requests browser notification permission on first load
- Sets a `setTimeout` for every lead with a pending follow-up
- Fires `"Follow up: [Name] · [note]"` desktop notification exactly when due
- Works even when the tab is in the background

### 3. Mobile-optimised button layout (`CallCRM.tsx` → `LeadCard`)
- **Mobile**: full-width bottom action bar per card — Call / WhatsApp / Note / Copy — all visible without scrolling
- **Desktop**: compact icon row inline
- No buttons hidden off-screen

## How the routing works
- `vercel.json`: `/crm/sales/*` → `dist/crm/index.html` (Vite Sales CRM), before the catch-all `/crm/:path*` → `dist/index.html` (admin CRM)
- `copy-main-website.mjs`: injects a `history.pushState` interceptor into `dist/index.html` so when a user in the admin CRM SPA clicks "Call CRM" (which calls pushState to `/crm/sales/crm`), we do a full `location.href` reload instead — this lets Vercel serve the right app
- Session sharing: both apps use the same Supabase project, so the localStorage auth token is shared — no re-login needed

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_