### PR TITLE
fix: /crm shows admin CRM not Sales CRM (trailing slash routing)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,13 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
+  "trailingSlash": false,
   "rewrites": [
     { "source": "/crm/assets/:path*", "destination": "/crm/assets/:path*" },
     { "source": "/crm/sales/:path*", "destination": "/crm/index.html" },
     { "source": "/crm/sales", "destination": "/crm/index.html" },
     { "source": "/crm", "destination": "/index.html" },
+    { "source": "/crm/", "destination": "/index.html" },
     { "source": "/crm/:path*", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Problem\n\nAfter the Sales CRM Vite build was wired up, visiting `fanbegroup.com/crm` started loading the **Vite-built Sales CRM** (`dist/crm/index.html`) instead of the **pre-built admin CRM** (`dist/index.html`).\n\n## Root Cause\n\nVercel's static file hosting detects that `dist/crm/` exists as a directory and automatically **301-redirects `/crm` → `/crm/`** before any rewrite rules are evaluated. The browser then requests `/crm/`, which falls through to `dist/crm/index.html` (the Sales CRM directory index).\n\n## Fix\n\n1. **`trailingSlash: false`** — tells Vercel not to append trailing slashes, disabling the automatic `/crm` → `/crm/` redirect.\n2. Added explicit `{ source: \"/crm/\", destination: \"/index.html\" }` rewrite as belt-and-suspenders, in case `/crm/` is ever requested directly.\n\n## After merge\n- `fanbegroup.com/crm` → admin CRM (Super Admin dashboard)\n- `fanbegroup.com/crm/admin/*` → admin CRM routes\n- `fanbegroup.com/crm/sales/*` → Sales CRM (telecaller workflow)\n- `fanbegroup.com/crm/login` → admin CRM login page"}]

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_