### PR TITLE
fix: /crm/login always serves admin CRM (remove trailingSlash, fix Sales CRM route)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,16 +20,16 @@ import PromotionMaterials from '@/pages/PromotionMaterials'
 
 function Guard({children}:{children:any}){
   const[session,setSession]=useState<any>(undefined)
-  useEffect(()=>{supabase.auth.getSession().then(({data})=>setSession(data.session));const{data:{subscription}}=supabase.auth.onAuthStateChange((_,s)=>setSession(s));return()=>subscription.unsubscribe()},[])
+  useEffect(()=>{supabase.auth.getSession().then(({data})=>setSession(data.session));const{data:{subscription}}=supabase.auth.onAuthStateChange((_,s)=>setSession(s));return()=>subscription.unsubscribe()},[]);
   if(session===undefined)return<div className="min-h-screen flex items-center justify-center"><div className="w-8 h-8 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"/></div>
-  if(!session)return<Navigate to="/login" replace/>
+  if(!session)return<Navigate to="/sales/login" replace/>
   return children
 }
 
 export default function App(){
   return(
     <Routes>
-      <Route path="/login" element={<Login/>}/>
+      <Route path="/sales/login" element={<Login/>}/>
       <Route element={<Guard><AppLayout/></Guard>}>
         <Route path="/" element={<Dashboard/>}/>
         <Route path="/analytics" element={<Analytics/>}/>

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "trailingSlash": false,
   "rewrites": [
     { "source": "/crm/assets/:path*", "destination": "/crm/assets/:path*" },
     { "source": "/crm/sales/:path*", "destination": "/crm/index.html" },


### PR DESCRIPTION
## Problem\n\n`fanbegroup.com/crm/login` was showing the **Sales CRM login** (\"Fanbe Group / Employee Sales CRM\") instead of the **admin CRM login** (\"Fanbe CRM / Authorized Personnel Only\").\n\n## Root Causes\n\n### 1. `trailingSlash: false` broke Vercel rewrite matching\nPR #72 added `\"trailingSlash\": false` to fix the `/crm` → Sales CRM bug. This accidentally changed how Vercel resolves rewrite destinations for paths under `/crm/*`, causing `/crm/login` to fall through to `dist/crm/index.html` (Sales CRM) instead of being rewritten to `dist/index.html` (admin CRM).\n\n**Fix:** Remove `trailingSlash: false`. The explicit `{ source: \"/crm/\", destination: \"/index.html\" }` rewrite (also added in PR #72) is sufficient to handle the trailing-slash directory redirect for `/crm/`.\n\n### 2. Sales CRM router claimed `/crm/login`\nWith `base: '/crm/'`, the Sales CRM's `<Route path=\"/login\">` matched `/crm/login`. When unauthenticated employees hit the Guard, `<Navigate to=\"/login\">` did a client-side pushState to `/crm/login` — staying inside the Sales CRM SPA and showing its login page.\n\n**Fix:** Move Sales CRM login route to `/sales/login` → full URL `/crm/sales/login`. This is already covered by the `{ source: \"/crm/sales/:path*\", destination: \"/crm/index.html\" }` Vercel rewrite.\n\n## URL map after this fix\n\n| URL | Serves |\n|-----|--------|\n| `fanbegroup.com/crm` | Admin CRM (pre-built) |\n| `fanbegroup.com/crm/login` | Admin CRM login |\n| `fanbegroup.com/crm/admin/*` | Admin CRM (all routes) |\n| `fanbegroup.com/crm/sales/login` | Sales CRM login |\n| `fanbegroup.com/crm/sales/crm` | Sales CRM (Call CRM) |\n| `fanbegroup.com/crm/sales/my-leads` | Sales CRM (My Leads) |"}]

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_