### PR TITLE
fix: use Vercel routes (not rewrites) so /crm serves admin CRM

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,10 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "rewrites": [
-    { "source": "/crm/assets/:path*", "destination": "/crm/assets/:path*" },
-    { "source": "/crm/sales/:path*", "destination": "/crm/index.html" },
-    { "source": "/crm/sales", "destination": "/crm/index.html" },
-    { "source": "/crm", "destination": "/index.html" },
-    { "source": "/crm/", "destination": "/index.html" },
-    { "source": "/crm/:path*", "destination": "/index.html" }
+  "routes": [
+    { "src": "/crm/assets/(.*)", "dest": "/crm/assets/$1" },
+    { "src": "/crm/sales(/.*)?", "dest": "/crm/index.html" },
+    { "src": "/crm(/.*)?", "dest": "/index.html" },
+    { "handle": "filesystem" }
   ]
 }


### PR DESCRIPTION
## Root cause (definitive)\n\nVercel's `rewrites` **cannot override static directory indexes**. Because `dist/crm/` exists as a directory (Vite's output), Vercel serves `dist/crm/index.html` (the Sales CRM) for requests to `/crm` before rewrites are even checked. This is documented Vercel behavior: static files take precedence over rewrites.\n\n## Fix\n\nSwitch from `rewrites` to Vercel's `routes` config. Routes are processed **before** the filesystem, so `/crm(/.*)?` → `/index.html` correctly intercepts all admin CRM paths before Vercel can serve the `dist/crm/` directory.\n\n```json\n\"routes\": [\n  { \"src\": \"/crm/assets/(.*)\",  \"dest\": \"/crm/assets/$1\" },\n  { \"src\": \"/crm/sales(/.*)?\"   \"dest\": \"/crm/index.html\" },\n  { \"src\": \"/crm(/.*)?\"         \"dest\": \"/index.html\" },\n  { \"handle\": \"filesystem\" }\n]\n```\n\n## URL routing after this fix\n\n| Request | Served |\n|---------|--------|\n| `/crm` | Admin CRM (`dist/index.html`) |\n| `/crm/` | Admin CRM |\n| `/crm/login` | Admin CRM login |\n| `/crm/admin/dashboard` | Admin CRM |\n| `/crm/sales/login` | Sales CRM (`dist/crm/index.html`) |\n| `/crm/sales/crm` | Sales CRM |\n| `/crm/assets/*.js` | Sales CRM static assets |\n| `/assets/*.js` | Admin CRM static assets (via filesystem) |"}]

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_