### PR TITLE
fix: move Sales CRM to /sales/* — eliminate /crm namespace conflict

### DIFF
--- a/scripts/copy-main-website.mjs
+++ b/scripts/copy-main-website.mjs
@@ -26,15 +26,15 @@ function copyRecursive(src, dest) {
 copyRecursive(SRC, DEST)
 console.log('✅ Main website files copied into dist/')
 
-// Patch 1: rename dist/crm/index.html → dist/crm/app.html
-// Vercel serves dist/crm/index.html as a static directory index for /crm
+// Patch 1: rename dist/sales/index.html → dist/sales/app.html
+// Vercel serves dist/sales/index.html as a static directory index for /sales
 // before any routing rules fire. Renaming it removes the conflict so that
-// the /crm → /index.html rewrite can serve the admin CRM correctly.
-const salesCrmIndex = path.join(DEST, 'crm', 'index.html')
-const salesCrmApp   = path.join(DEST, 'crm', 'app.html')
+// /sales/* → /sales/app.html rewrites fire correctly.
+const salesCrmIndex = path.join(DEST, 'sales', 'index.html')
+const salesCrmApp   = path.join(DEST, 'sales', 'app.html')
 if (existsSync(salesCrmIndex)) {
   renameSync(salesCrmIndex, salesCrmApp)
-  console.log('🔧 Renamed dist/crm/index.html → dist/crm/app.html (avoids directory-index conflict)')
+  console.log('🔧 Renamed dist/sales/index.html → dist/sales/app.html (avoids directory-index conflict)')
 }
 
 // Patch 2: sidebar nav labels in the compiled admin CRM bundle
@@ -56,9 +56,9 @@ if (existsSync(assetsDir)) {
 }
 
 // Patch 3: inject navigation interceptor into dist/index.html so that
-// clicking "Call CRM" (or any /crm/sales/* link) inside the admin CRM SPA
+// clicking "Call CRM" (or any /sales/* link) inside the admin CRM SPA
 // triggers a full page reload — this hands control to the Vite-built
-// Sales CRM which has smart notes and browser notifications.
+// Sales CRM.
 const indexPath = path.join(DEST, 'index.html')
 if (existsSync(indexPath)) {
   let html = readFileSync(indexPath, 'utf8')
@@ -68,7 +68,7 @@ if (existsSync(indexPath)) {
   var _replace = history.replaceState.bind(history);
   function intercept(url) {
     if (!url) return false;
-    try { var p = new URL(String(url), location.href).pathname; if (p.startsWith('/crm/sales/')) { location.href = p; return true; } } catch(e) {}
+    try { var p = new URL(String(url), location.href).pathname; if (p.startsWith('/sales/')) { location.href = p; return true; } } catch(e) {}
     return false;
   }
   history.pushState = function(s,t,url){ if(intercept(url)) return; return _push(s,t,url); };
@@ -77,5 +77,5 @@ if (existsSync(indexPath)) {
 </script>`
   html = html.replace('</head>', interceptScript + '\n</head>')
   writeFileSync(indexPath, html, 'utf8')
-  console.log('🔧 Injected /crm/sales/* navigation interceptor into dist/index.html')
+  console.log('🔧 Injected /sales/* navigation interceptor into dist/index.html')
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,19 +22,19 @@ function Guard({children}:{children:any}){
   const[session,setSession]=useState<any>(undefined)
   useEffect(()=>{supabase.auth.getSession().then(({data})=>setSession(data.session));const{data:{subscription}}=supabase.auth.onAuthStateChange((_,s)=>setSession(s));return()=>subscription.unsubscribe()},[]);
   if(session===undefined)return<div className="min-h-screen flex items-center justify-center"><div className="w-8 h-8 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"/></div>
-  if(!session)return<Navigate to="/sales/login" replace/>
+  if(!session)return<Navigate to="/login" replace/>
   return children
 }
 
 export default function App(){
   return(
     <Routes>
-      <Route path="/sales/login" element={<Login/>}/>
+      <Route path="/login" element={<Login/>}/>
       <Route element={<Guard><AppLayout/></Guard>}>
         <Route path="/" element={<Dashboard/>}/>
         <Route path="/analytics" element={<Analytics/>}/>
-        <Route path="/sales/crm" element={<CallCRM/>}/>
-        <Route path="/sales/tools" element={<PromotionMaterials/>}/>
+        <Route path="/crm" element={<CallCRM/>}/>
+        <Route path="/tools" element={<PromotionMaterials/>}/>
         <Route path="/projects" element={<Projects/>}/>
         <Route path="/plots" element={<Plots/>}/>
         <Route path="/bookings" element={<Bookings/>}/>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,7 +7,7 @@ const NAV = [
   { group:'Main', items:[
     {to:'/',icon:LayoutDashboard,label:'rashboard'},
     {to:'/analytics',icon:BarChart2,label:'Analytics'},
-    {to:'/sales/crm',icon:Phone,label:'Call CRM'},
+    {to:'/crm',icon:Phone,label:'Call CRM'},
   ]},
   { group:'Real Estate', items:[
     {to:'/projects',icon:Building2,label:'Projects'},
@@ -16,7 +16,7 @@ const NAV = [
     {to:'/payments',icon:CreditCard,label:'Payments'},
   ]},
   { group:'Sales Tools', items:[
-    {to:'/sales/tools',icon:Megaphone,label:'Promo Materials'},
+    {to:'/tools',icon:Megaphone,label:'Promo Materials'},
   ]},
   { group:'Reports', items:[
     {to:'/reports',icon:FileText,label:'Reports'},

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ const qc = new QueryClient({ defaultOptions: { queries: { staleTime: 120000, ret
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <BrowserRouter basename="/crm">
+      <BrowserRouter basename="/sales">
         <App />
         <Toaster position="top-right" toastOptions={{ duration: 4000 }} />
       </BrowserRouter>

--- a/vercel.json
+++ b/vercel.json
@@ -2,10 +2,10 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/crm/assets/:path*", "destination": "/crm/assets/:path*" },
-    { "source": "/crm/sales/:path*", "destination": "/crm/app.html" },
-    { "source": "/crm/sales",        "destination": "/crm/app.html" },
-    { "source": "/crm",              "destination": "/index.html" },
-    { "source": "/crm/:path*",       "destination": "/index.html" }
+    { "source": "/sales/assets/:path*", "destination": "/sales/assets/:path*" },
+    { "source": "/sales/:path*",        "destination": "/sales/app.html" },
+    { "source": "/sales",              "destination": "/sales/app.html" },
+    { "source": "/crm",               "destination": "/index.html" },
+    { "source": "/crm/:path*",        "destination": "/index.html" }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 export default defineConfig({
-  base: '/crm/',
-  build: { outDir: 'dist/crm' },
+  base: '/sales/',
+  build: { outDir: 'dist/sales' },
   plugins: [react()],
   resolve: { alias: { '@': path.resolve(__dirname, './src') } },
 })


### PR DESCRIPTION
## Problem

`fanbegroup.com/crm` and `/crm/login` were serving the Sales CRM (Vite app) instead of the admin CRM (pre-built). Root cause: Vite outputs to `dist/crm/` with `base: '/crm/'`, so Vercel's static file serving picks up `dist/crm/` as a directory index for all `/crm/*` requests before any rewrite rules fire. Six previous PRs (#72–#76) couldn't fix this because the namespace conflict was fundamental.

## Solution

Move the Sales CRM entirely out of `/crm/*` to its own `/sales/*` namespace.

## Changes

| File | Change |
|------|--------|
| `vite.config.ts` | `base: '/sales/'`, `outDir: 'dist/sales'` |
| `src/main.tsx` | `basename="/sales"` |
| `src/App.tsx` | Routes: `/login`, `/crm`, `/tools` (basename handles `/sales` prefix) |
| `src/components/layout/Sidebar.tsx` | Nav links updated to `/crm` and `/tools` |
| `vercel.json` | `/sales/*` → `dist/sales/app.html`; `/crm/*` → `dist/index.html` (admin) |
| `scripts/copy-main-website.mjs` | Rename `dist/sales/index.html` → `dist/sales/app.html`; interceptor updated to `/sales/` |

## URL mapping after this PR

| URL | Serves |
|-----|--------|
| `fanbegroup.com/crm` | Admin CRM (pre-built) ✅ |
| `fanbegroup.com/crm/admin/dashboard` | Admin CRM ✅ |
| `fanbegroup.com/sales` | Sales CRM login ✅ |
| `fanbegroup.com/sales/login` | Sales CRM login ✅ |
| `fanbegroup.com/sales/crm` | Call CRM page ✅ |

## Test plan

- [ ] Visit `fanbegroup.com/crm` → should show admin CRM (dark sidebar, "Fanbe Group / Control")
- [ ] Visit `fanbegroup.com/crm/login` → should show admin CRM login, not telecaller login
- [ ] Visit `fanbegroup.com/sales` → should show Sales CRM login
- [ ] Login to Sales CRM → dashboard loads, "Call CRM" link navigates to `/sales/crm`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_