### PR TITLE
fix: land on Call CRM after login, not broker Dashboard

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -17,7 +17,7 @@ export default function Login() {
       toast.error(error.message)
     } else {
       toast.success('Welcome back!')
-      navigate('/')
+      navigate('/crm')
     }
     setLoading(false)
   }
@@ -35,13 +35,13 @@ export default function Login() {
             <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
             <input type="email" value={email} onChange={e => setEmail(e.target.value)} required
               className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="admin@fanbegroup.com" />
+              placeholder="admin@fanbegroup.com" autoComplete="email" />
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
             <input type="password" value={password} onChange={e => setPassword(e.target.value)} required
               className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="••••••••" />
+              placeholder="••••••••" autoComplete="current-password" />
           </div>
           <button type="submit" disabled={loading}
             className="w-full bg-blue-600 text-white rounded-lg py-2.5 text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,7 @@
   "rewrites": [
     { "source": "/sales/assets/:path*", "destination": "/sales/assets/:path*" },
     { "source": "/sales/:path*",        "destination": "/sales/app.html" },
+    { "source": "/sales/",             "destination": "/sales/app.html" },
     { "source": "/sales",              "destination": "/sales/app.html" },
     { "source": "/crm",               "destination": "/index.html" },
     { "source": "/crm/:path*",        "destination": "/index.html" }


### PR DESCRIPTION
## Problem\n\nAfter signing in at `/sales/login`, telecallers were redirected to `/sales/` (Dashboard) instead of Call CRM. The Dashboard shows broker-admin stats (payouts, KYC counts) — wrong page for a telecaller. This appeared as \"redirect to a different page/login\" because the app was not landing on the expected CRM view.\n\nA secondary risk: `navigate('/')` in React Router generates `/sales/` (trailing slash) which was not explicitly covered in `vercel.json` rewrites.\n\n## Changes\n\n### `src/pages/Login.tsx`\n- `navigate('/crm')` instead of `navigate('/')` — lands on Call CRM after login\n- Added `autoComplete` attributes to fix the DOM warning visible in devtools\n\n### `vercel.json`\n- Added `\"/sales/\"` → `\"/sales/app.html\"` rewrite to handle trailing-slash navigation cleanly\n\n## Test plan\n- [ ] Visit `fanbegroup.com/crm/sales/crm` → redirected to `fanbegroup.com/sales/crm`\n- [ ] Not logged in → redirected to `/sales/login`\n- [ ] Log in → lands on **Call CRM** (not Dashboard)\n- [ ] Call CRM shows lead list with big Call + WhatsApp buttons on mobile\n\nhttps://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_