### PR TITLE
fix: hard redirect to /sales/crm after login (bypass basename bug)

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react'
 import { supabase } from '@/lib/supabase'
-import { useNavigate } from 'react-router-dom'
 import toast from 'react-hot-toast'
 
 export default function Login() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
-  const navigate = useNavigate()
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault()
@@ -15,11 +13,13 @@ export default function Login() {
     const { error } = await supabase.auth.signInWithPassword({ email, password })
     if (error) {
       toast.error(error.message)
+      setLoading(false)
     } else {
       toast.success('Welcome back!')
-      navigate('/crm')
+      // Hard redirect — bypasses React Router basename ambiguity so we
+      // always land on /sales/crm (our Vite CRM), not /crm (admin app).
+      window.location.href = '/sales/crm'
     }
-    setLoading(false)
   }
 
   return (


### PR DESCRIPTION
## Problem\n\nAfter login, `navigate('/crm')` in React Router with `basename=\"/sales\"` was navigating to `fanbegroup.com/crm` (the pre-built admin app) instead of `fanbegroup.com/sales/crm` (our improved Vite CRM).\n\nRoot cause: React Router v6's `navigate()` does not always prepend the basename when given an absolute path — the behaviour differs across minor versions. The result was users landing in the wrong app after every login.\n\n## Fix\n\nReplace `navigate('/crm')` with `window.location.href = '/sales/crm'` — an explicit hard redirect that is completely unambiguous regardless of React Router version or basename config.\n\nAlso removed the now-unnecessary `useNavigate` import.\n\n## Test plan\n- [ ] Visit `fanbegroup.com/crm/sales/crm` → redirected to `/sales/crm`\n- [ ] Not logged in → `/sales/login`\n- [ ] Sign in → hard redirect to `fanbegroup.com/sales/crm` ✓ (our Vite CRM, NOT admin app)\n- [ ] Call CRM loads with big mobile Call/WhatsApp buttons and quick-log row\n\nhttps://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_