### PR TITLE
fix: race condition causing post-login bounce back to /sales/login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,35 +18,63 @@ import Settings from '@/pages/Settings'
 import CallCRM from '@/pages/CallCRM'
 import PromotionMaterials from '@/pages/PromotionMaterials'
 
-function Guard({children}:{children:any}){
-  const[session,setSession]=useState<any>(undefined)
-  useEffect(()=>{supabase.auth.getSession().then(({data})=>setSession(data.session));const{data:{subscription}}=supabase.auth.onAuthStateChange((_,s)=>setSession(s));return()=>subscription.unsubscribe()},[]);
-  if(session===undefined)return<div className="min-h-screen flex items-center justify-center"><div className="w-8 h-8 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"/></div>
-  if(!session)return<Navigate to="/login" replace/>
+function Guard({ children }: { children: any }) {
+  const [session, setSession] = useState<any>(undefined)
+  const [tries, setTries] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    supabase.auth.getSession().then(({ data }) => {
+      if (!cancelled) setSession(data.session)
+    })
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_, s) => {
+      if (!cancelled) setSession(s)
+    })
+    return () => { cancelled = true; subscription.unsubscribe() }
+  }, [])
+
+  // If the session lookup returns null on the very first attempt right after
+  // a hard redirect from /sales/login, retry once after a short delay — the
+  // Supabase localStorage write occasionally lags the page navigation.
+  useEffect(() => {
+    if (session === null && tries < 3) {
+      const t = setTimeout(async () => {
+        const { data } = await supabase.auth.getSession()
+        setSession(data.session)
+        setTries(n => n + 1)
+      }, 250)
+      return () => clearTimeout(t)
+    }
+  }, [session, tries])
+
+  if (session === undefined || (session === null && tries < 3)) {
+    return <div className="min-h-screen flex items-center justify-center"><div className="w-8 h-8 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" /></div>
+  }
+  if (!session) return <Navigate to="/login" replace />
   return children
 }
 
-export default function App(){
-  return(
+export default function App() {
+  return (
     <Routes>
-      <Route path="/login" element={<Login/>}/>
-      <Route element={<Guard><AppLayout/></Guard>}>
-        <Route path="/" element={<Dashboard/>}/>
-        <Route path="/analytics" element={<Analytics/>}/>
-        <Route path="/crm" element={<CallCRM/>}/>
-        <Route path="/tools" element={<PromotionMaterials/>}/>
-        <Route path="/projects" element={<Projects/>}/>
-        <Route path="/plots" element={<Plots/>}/>
-        <Route path="/bookings" element={<Bookings/>}/>
-        <Route path="/payments" element={<Payments/>}/>
-        <Route path="/brokers" element={<Brokers/>}/>
-        <Route path="/kyc" element={<KYC/>}/>
-        <Route path="/payouts" element={<Payouts/>}/>
-        <Route path="/commission" element={<Commission/>}/>
-        <Route path="/reports" element={<Reports/>}/>
-        <Route path="/settings" element={<Settings/>}/>
+      <Route path="/login" element={<Login />} />
+      <Route element={<Guard><AppLayout /></Guard>}>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/analytics" element={<Analytics />} />
+        <Route path="/crm" element={<CallCRM />} />
+        <Route path="/tools" element={<PromotionMaterials />} />
+        <Route path="/projects" element={<Projects />} />
+        <Route path="/plots" element={<Plots />} />
+        <Route path="/bookings" element={<Bookings />} />
+        <Route path="/payments" element={<Payments />} />
+        <Route path="/brokers" element={<Brokers />} />
+        <Route path="/kyc" element={<KYC />} />
+        <Route path="/payouts" element={<Payouts />} />
+        <Route path="/commission" element={<Commission />} />
+        <Route path="/reports" element={<Reports />} />
+        <Route path="/settings" element={<Settings />} />
       </Route>
-      <Route path="*" element={<Navigate to="/" replace/>}/>
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import toast from 'react-hot-toast'
 
@@ -6,6 +6,23 @@ export default function Login() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
+
+  // If already signed in (e.g. returning visitor), skip the form entirely.
+  // Also redirects right after sign-in via the SIGNED_IN auth event — this
+  // fires AFTER the session is persisted to localStorage, avoiding a race
+  // where the destination page's Guard reads localStorage too early and
+  // bounces back to /sales/login.
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      if (data.session) window.location.href = '/sales/crm'
+    })
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if ((event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') && session) {
+        window.location.href = '/sales/crm'
+      }
+    })
+    return () => subscription.unsubscribe()
+  }, [])
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault()
@@ -16,9 +33,8 @@ export default function Login() {
       setLoading(false)
     } else {
       toast.success('Welcome back!')
-      // Hard redirect — bypasses React Router basename ambiguity so we
-      // always land on /sales/crm (our Vite CRM), not /crm (admin app).
-      window.location.href = '/sales/crm'
+      // The onAuthStateChange listener above will redirect once the session
+      // is fully persisted. Keep `loading` true so the button stays disabled.
     }
   }
 


### PR DESCRIPTION
## Problem

After login, even with the explicit `window.location.href = '/sales/crm'` redirect from PR #80, the user kept landing back at `/sales/login`.

Root cause: a race condition between Supabase's localStorage session-persistence and the cross-page navigation. The sequence was:

1. `signInWithPassword()` promise resolves
2. `window.location.href = '/sales/crm'` fires immediately
3. Browser starts navigating before Supabase finishes writing to localStorage
4. New page loads, Guard runs `getSession()` → returns `null`
5. Guard redirects back to `/login`

## Fix (two parts)

### `src/pages/Login.tsx`
- Listen for the `SIGNED_IN` event on `onAuthStateChange` (fires AFTER persistence) and redirect from there instead of immediately after the promise resolves
- On mount, check if a session already exists and skip the form

### `src/App.tsx` Guard
- If `getSession()` returns `null` on the first attempt, retry up to 3 times at 250ms intervals before giving up and redirecting to login
- Defensive measure against any remaining storage-write lag

## Test plan
- [ ] Visit `/crm/sales/crm` → redirected to `/sales/crm` → login page  
- [ ] Sign in → stays on Call CRM (no bounce back to login)
- [ ] Refresh on `/sales/crm` while logged in → session restored, no flash of login

https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TthV8xeXJSj3CiGxi2h2e3)_