### PR TITLE
fix(crm): show banner when notifications are blocked + recover without reload

### DIFF
--- a/src/pages/CallCRM.tsx
+++ b/src/pages/CallCRM.tsx
@@ -84,6 +84,26 @@ export default function CallCRM() {
     }
   }
 
+  // Click handler for the always-visible notification status pill.
+  // Behaviour adapts to the current permission state so the telecaller has one obvious thing to tap.
+  const handleNotifPillClick = () => {
+    if (notifPerm === 'default') return handleEnableNotifs()
+    if (notifPerm === 'granted') {
+      try {
+        new Notification('🔔 FanBe CRM test', { body: 'Notifications are working. You will get alerts for new leads & callbacks.', icon: '/crm/favicon.ico' })
+        toast.success('Test notification sent — check your screen')
+      } catch {
+        toast.error('Could not fire a test notification')
+      }
+      return
+    }
+    if (notifPerm === 'denied') {
+      toast.error('Blocked. Tap the lock icon next to the URL → Permissions → Notifications → Allow, then come back.', { duration: 7000 })
+      return
+    }
+    toast.error('This browser does not support notifications')
+  }
+
   const { data: leads = [], isLoading } = useQuery({
     queryKey: ['crm_leads'],
     queryFn: async () => {
@@ -250,6 +270,7 @@ export default function CallCRM() {
           <p className="text-sm text-gray-500">{greeting()}, telecaller</p>
         </div>
         <div className="flex items-center gap-2">
+          <NotifStatusPill state={notifPerm} onClick={handleNotifPillClick} />
           <div className="relative">
             <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400"/>
             <Input value={q} onChange={(e: any) => setQ(e.target.value)} placeholder="Search leads\u2026" className="pl-7 w-56"/>
@@ -412,6 +433,29 @@ function LeadCard({ idx, lead, onOpen, onQuickLog, quickLogging }: {
 
 function Pill({ label, color }: { label: string; color: string }) {
   return <span className={`px-3 py-1 rounded-full text-xs font-medium border ${color}`}>{label}</span>
+}
+
+function NotifStatusPill({ state, onClick }: {
+  state: NotificationPermission | 'unsupported'
+  onClick: () => void
+}) {
+  const cfg = {
+    granted:     { Icon: BellRing, label: 'Alerts on',      cls: 'bg-emerald-50 text-emerald-700 border-emerald-200 hover:bg-emerald-100',         title: 'Tap to fire a test notification' },
+    default:     { Icon: BellRing, label: 'Enable alerts',  cls: 'bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100 animate-pulse',        title: 'Tap to enable notifications' },
+    denied:      { Icon: BellOff,  label: 'Alerts blocked', cls: 'bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100',                  title: 'Tap for instructions to unblock' },
+    unsupported: { Icon: BellOff,  label: 'No alerts',      cls: 'bg-gray-100 text-gray-500 border-gray-200 cursor-not-allowed',                    title: 'Notifications are not supported in this browser' },
+  }[state]
+  const { Icon, label, cls, title } = cfg
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${cls}`}>
+      <Icon size={14} />
+      <span className="hidden sm:inline">{label}</span>
+    </button>
+  )
 }
 
 function AddLeadModal({ open, onClose, onSubmit, saving }: {

--- a/src/pages/CallCRM.tsx
+++ b/src/pages/CallCRM.tsx
@@ -54,6 +54,16 @@ export default function CallCRM() {
   // Track notification permission so we can show/hide the banner reactively
   const [notifPerm, setNotifPerm] = useState<NotificationPermission | 'unsupported'>(getNotifPerm)
 
+  // Re-check permission when the tab regains focus — covers the case where the user
+  // changes the setting via the browser's lock-icon UI (no event fires for that).
+  useEffect(() => {
+    const onVis = () => {
+      if (document.visibilityState === 'visible') setNotifPerm(getNotifPerm())
+    }
+    document.addEventListener('visibilitychange', onVis)
+    return () => document.removeEventListener('visibilitychange', onVis)
+  }, [])
+
   // Browsers REQUIRE a direct user gesture to show the permission prompt.
   // Calling requestPermission() in useEffect silently fails in Chrome/Firefox.
   // We show a banner instead and only call requestPermission() on button click.
@@ -202,11 +212,24 @@ export default function CallCRM() {
             className="flex-shrink-0 px-3 py-1.5 rounded-lg bg-blue-600 text-white text-xs font-medium hover:bg-blue-700 active:bg-blue-800">
             Enable
           </button>
+        </div>
+      )}
+
+      {/* Denied: telecaller is stuck — give them recovery instructions + a re-check button */}
+      {notifPerm === 'denied' && (
+        <div className="flex items-start gap-3 px-4 py-3 bg-amber-50 border border-amber-200 text-amber-900 rounded-xl">
+          <BellOff size={18} className="flex-shrink-0 text-amber-600 mt-0.5" />
+          <div className="text-sm flex-1">
+            <p className="font-semibold mb-0.5">Notifications are blocked</p>
+            <p className="text-xs text-amber-800 leading-snug">
+              You won&apos;t get new-lead or callback alerts. To enable: tap the lock / info icon next to the URL &rarr; Permissions &rarr; Notifications &rarr; Allow. Then tap Re-check.
+            </p>
+          </div>
           <button
-            onClick={() => setNotifPerm('denied')}
-            className="flex-shrink-0 p-1.5 rounded-lg text-blue-400 hover:text-blue-700 hover:bg-blue-100"
-            title="Dismiss">
-            <BellOff size={15} />
+            onClick={() => setNotifPerm(getNotifPerm())}
+            className="flex-shrink-0 px-3 py-1.5 rounded-lg bg-amber-600 text-white text-xs font-medium hover:bg-amber-700 active:bg-amber-800"
+            title="Re-check after enabling in browser settings">
+            Re-check
           </button>
         </div>
       )}


### PR DESCRIPTION
## Why

Beena (and any other telecaller whose browser permission was already `denied`) saw **no notification banner** on `/crm/sales/crm` and had no in-app path to recover. The existing banner only renders for `Notification.permission === 'default'`, which is a one-time state — once dismissed, denied, or auto-blocked, the UI is silent forever and the telecaller silently misses callback alerts.

## What changed (`src/pages/CallCRM.tsx`)

1. **New amber "Notifications are blocked" banner** for the `denied` state. Includes plain-language instructions ("tap the lock / info icon next to the URL → Permissions → Notifications → Allow") and a **Re-check** button that re-reads `Notification.permission` so the banner clears in-place once she flips the setting.
2. **`visibilitychange` listener** refreshes `notifPerm` whenever the tab regains focus. Browsers don't fire an event when permission changes via the lock-icon UI, so without this the banner state is stale until full reload.
3. **Removed the fake-denied dismiss button** on the default banner. It called `setNotifPerm('denied')`, which only flipped local state without actually denying — and after change #1 it would have incorrectly triggered the new blocked banner.

## Test plan
- [ ] Open `/crm/sales/crm` in a browser where notifications were previously blocked → amber banner appears with Re-check button
- [ ] Click 🔒 → allow notifications → tap **Re-check** → amber banner clears, no reload needed
- [ ] Open in a fresh browser (permission = default) → blue "Enable notifications" banner appears
- [ ] Click **Enable** → native prompt fires → on grant, test notification fires and banner disappears
- [ ] Switch tabs, change permission in browser settings, switch back → banner state updates on focus
- [ ] Verify no banner appears when permission is `granted`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn7q5xt5h34Ao3G5jNbw1g)_