### PR TITLE
fix(vercel): make /sales/crm actually load the Vite CRM (unblocks all prior telecaller UX work)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,11 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/crm",        "destination": "/index.html" },
-    { "source": "/crm/",       "destination": "/index.html" },
-    { "source": "/crm/:path*", "destination": "/index.html" }
+    { "source": "/crm",          "destination": "/index.html" },
+    { "source": "/crm/",         "destination": "/index.html" },
+    { "source": "/crm/:path*",   "destination": "/index.html" },
+    { "source": "/sales",        "destination": "/sales/app.html" },
+    { "source": "/sales/",       "destination": "/sales/app.html" },
+    { "source": "/sales/:path*", "destination": "/sales/app.html" }
   ]
 }


### PR DESCRIPTION
## Why this matters

While debugging the "where is the notification banner?" issue, I traced the deployment architecture and found that **the entire CallCRM.tsx codebase — banners, status pill, quick-log buttons, mobile call/WhatsApp bar — has been deployed but unreachable in production**.

### How the production deploy is actually wired

- `dist/index.html` ← copied from `main-website/index.html` (a **pre-built admin bundle**, 1.2 MB compiled JS, no source)
- `dist/sales/app.html` ← from Vite build, after `copy-main-website.mjs` renames `dist/sales/index.html` → `app.html`
- The pre-built admin's `index.html` is patched to inject this script:
  ```js
  if (location.pathname === '/crm/sales/crm' && hasSupabaseSession())
    location.replace('/sales/crm')
  ```
- `vercel.json` rewrote `/crm/*` → `/index.html` but had **no rule for `/sales/*`**. So:
  - `/crm/sales/crm` → pre-built admin loads, tries to redirect to `/sales/crm`
  - `/sales/crm` → **404** (no file, no rewrite)
  - Telecaller stays on `/crm/sales/crm` looking at the pre-built admin forever — never sees any of the work in `src/`

This is why Beena reported "I can't see anything new" after every commit.

## Fix

Three rewrites in `vercel.json`:

```json
{ "source": "/sales",        "destination": "/sales/app.html" },
{ "source": "/sales/",       "destination": "/sales/app.html" },
{ "source": "/sales/:path*", "destination": "/sales/app.html" }
```

Vercel tries the filesystem before applying rewrites, so existing `/sales/assets/*` static files (Vite-built JS, CSS, images) are still served directly. Only paths with no backing file — `/sales/crm`, `/sales/login`, etc. — are rewritten to the SPA shell. `<BrowserRouter basename="/sales">` in `src/main.tsx` then strips the prefix so React Router matches the existing `<Route path="/crm" element={<CallCRM />} />`.

## Test plan
- [ ] Open preview URL `/sales/crm` directly → loads CallCRM.tsx (Sales Dashboard with "{greeting}, telecaller", Add lead button, NotifStatusPill in header)
- [ ] Open preview URL `/sales/app.html` → same content
- [ ] Open preview URL `/crm/sales/crm` while signed in → pre-built admin's redirect script fires → lands on `/sales/crm` showing the Vite CRM (not 404)
- [ ] Reload `/sales/crm` (deep link) → SPA shell loads, router routes to `/crm`, CallCRM renders (no 404)
- [ ] Visit `/sales/assets/*.js` URLs from devtools network tab → static files still serve correctly (not the HTML shell)
- [ ] Confirm `/crm/admin/dashboard` and other pre-built admin routes still serve the pre-built admin (no regression)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn7q5xt5h34Ao3G5jNbw1g)_