### PR TITLE
fix(prod): SPA fallback vercel.json + /crm/sales/crm route alias

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -192,6 +192,9 @@ const AppRoutes = ({ onBookSiteVisit }) => {
 
                    {/* Sales Routes */}
                    <Route path="sales/dashboard" element={<SalesExecutiveDashboard />} />
+                   {/* `sales/crm` is the production telecaller URL (fanbegroup.com/crm/sales/crm).
+                       Alias it to MyLeads so the live link doesn't 404. */}
+                   <Route path="sales/crm" element={<MyLeads />} />
                    {/* Fallback to desktop dash if not mobile */}
                    {!isMobile && <Route path="employee-dashboard" element={<EmployeeDashboard />} />}
                    

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Closing — production has been promoted back to the `main` deployment (`b7vnd7NWU`), so the live `fanbegroup.com/crm/sales/crm` is served by the compiled bundle in `main-website/assets/` again. This PR was patching the wrong source. The features from PR #88 still live on `crm-real-source` as a portable reference for the day the real CRM source is identified.