### PR TITLE
feat(crm): real Supabase auth + paginated fast leads + perf migration script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Supabase credentials (also hardcoded as fallbacks in src/lib/supabase.js).
+# Set these in Vercel project settings → Environment Variables so they
+# override the fallback for production deployments.
+VITE_SUPABASE_URL=https://mfgjzkaabyltscgrkhdz.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1mZ2p6a2FhYnlsdHNjZ3JraGR6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzEzNDAzNjQsImV4cCI6MjA4NjkxNjM2NH0.V6uWBH72rgp0UEFdB9aT8qrG4YFYhnERWZO1t976_tM

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 .env
 .env.*
 .env.local
+!.env.example
 .DS_Store
 *.log
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
+    "@supabase/supabase-js": "^2.45.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "date-fns": "^3.3.1",

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,124 +1,155 @@
-
-import React, { createContext, useContext, useState, useEffect } from 'react';
-import { initializeData } from '@/lib/dataInitializer';
-import { initializeUserDatabase, findUser, verifyPassword } from '@/lib/authUtils';
-import { logLoginAttempt } from '@/lib/loginLogger';
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
 
 const AuthContext = createContext(null);
 
+/**
+ * AuthProvider — real Supabase auth (replaces the old localStorage-only
+ * `authUtils` flow). Session is persisted to localStorage by Supabase
+ * itself under the `fanbe-crm-auth` key. We map the auth user → public.profiles
+ * row to recover {role, name, username, etc.} that the rest of the app expects.
+ *
+ * Login accepts username OR email. If the input contains '@' we use it as
+ * email directly; otherwise we look up the email from profiles by username.
+ */
 export const AuthProvider = ({ children }) => {
-  const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [authUser, setAuthUser] = useState(null);   // raw supabase.auth.User
+  const [profile, setProfile]   = useState(null);   // public.profiles row
+  const [loading, setLoading]   = useState(true);
 
-  // Initialize Data & Load Session
-  useEffect(() => {
-    // Ensure basic data exists
-    initializeData();
-    // Ensure user DB exists
-    initializeUserDatabase();
-
-    // Restore session from localStorage
-    const storedUser = localStorage.getItem('crm_user');
-    if (storedUser) {
-      try {
-        const parsedUser = JSON.parse(storedUser);
-        // Verify token validity or session expiry here if needed
-        // For now, assume stored user is valid
-        setUser(parsedUser);
-      } catch (e) {
-        console.error("Failed to parse stored user", e);
-        localStorage.removeItem('crm_user');
-      }
+  const loadProfile = useCallback(async (userId) => {
+    if (!userId) {
+      setProfile(null);
+      return null;
     }
-    setLoading(false);
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('id, username, email, name, role, phone, department, status, permissions, last_login, metrics')
+      .eq('id', userId)
+      .single();
+    if (error) {
+      console.warn('[Auth] Failed to load profile:', error.message);
+      setProfile(null);
+      return null;
+    }
+    setProfile(data);
+    return data;
   }, []);
 
-  // Session Timeout Logic
   useEffect(() => {
-    if (!user) return;
+    let cancelled = false;
 
+    // Initial session restore
+    supabase.auth.getSession().then(async ({ data }) => {
+      if (cancelled) return;
+      const u = data.session?.user ?? null;
+      setAuthUser(u);
+      if (u) await loadProfile(u.id);
+      setLoading(false);
+    });
+
+    // Subscribe to auth state changes (login, logout, refresh)
+    const { data: sub } = supabase.auth.onAuthStateChange(async (_event, session) => {
+      if (cancelled) return;
+      const u = session?.user ?? null;
+      setAuthUser(u);
+      if (u) await loadProfile(u.id);
+      else setProfile(null);
+    });
+
+    return () => {
+      cancelled = true;
+      sub.subscription.unsubscribe();
+    };
+  }, [loadProfile]);
+
+  const logout = useCallback(async () => {
+    await supabase.auth.signOut();
+    setAuthUser(null);
+    setProfile(null);
+    window.location.href = '/crm/login';
+  }, []);
+
+  // Idle-timeout — 30 min, matches previous behavior
+  useEffect(() => {
+    if (!authUser) return;
     let timeoutId;
-    const timeoutDuration = 30 * 60 * 1000; // 30 minutes
-
-    const resetTimer = () => {
+    const reset = () => {
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
         alert('Session expired due to inactivity');
         logout();
-      }, timeoutDuration);
+      }, 30 * 60 * 1000);
     };
-
     const events = ['mousedown', 'keydown', 'scroll', 'touchstart'];
-    events.forEach(event => document.addEventListener(event, resetTimer));
-    resetTimer();
-
+    events.forEach(e => document.addEventListener(e, reset));
+    reset();
     return () => {
       clearTimeout(timeoutId);
-      events.forEach(event => document.removeEventListener(event, resetTimer));
+      events.forEach(e => document.removeEventListener(e, reset));
     };
-  }, [user]);
+  }, [authUser, logout]);
 
-  const login = (usernameOrId, password) => {
-    console.log(`[Auth] Attempting login for: ${usernameOrId}`);
-    
-    // 1. Normalize input
-    const cleanInput = usernameOrId.trim();
+  const login = async (usernameOrEmail, password) => {
+    const input = (usernameOrEmail || '').trim();
+    if (!input) return { success: false, message: 'Enter your username or email' };
+    if (!password) return { success: false, message: 'Enter your password' };
 
-    // 2. Find employee
-    const employee = findUser(cleanInput);
-
-    // 3. Validate
-    if (!employee) {
-      console.warn(`[Auth] Login failed: User ${cleanInput} not found.`);
-      logLoginAttempt({ username: cleanInput, status: 'Failed', reason: 'User not found' });
-      return { success: false, message: 'Username/ID not found.' };
+    // Resolve to an email — Supabase auth signs in by email
+    let email = input;
+    if (!input.includes('@')) {
+      const { data: prof, error } = await supabase
+        .from('profiles')
+        .select('email, status')
+        .eq('username', input)
+        .maybeSingle();
+      if (error || !prof) {
+        return { success: false, message: 'Username/ID not found.' };
+      }
+      if (prof.status && prof.status !== 'Active') {
+        return { success: false, message: 'Account Suspended. Contact Admin.' };
+      }
+      email = prof.email;
     }
 
-    // 4. Verify Password
-    if (!verifyPassword(password, employee.password)) {
-      console.warn(`[Auth] Login failed: Incorrect password for ${cleanInput}.`);
-      logLoginAttempt({ username: cleanInput, status: 'Failed', reason: 'Incorrect Password' });
-      return { success: false, message: 'Incorrect password' };
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      return {
+        success: false,
+        message: error.message.includes('Invalid') ? 'Incorrect password' : error.message,
+      };
     }
 
-    if (employee.status !== 'Active') {
-       console.warn(`[Auth] Login failed: User ${cleanInput} is suspended.`);
-       logLoginAttempt({ username: cleanInput, status: 'Failed', reason: 'Account Suspended' });
-       return { success: false, message: 'Account Suspended. Contact Admin.' };
+    if (data.user) {
+      const prof = await loadProfile(data.user.id);
+      // Best-effort last_login update (RLS allows users to update own profile)
+      supabase.from('profiles')
+        .update({ last_login: new Date().toISOString() })
+        .eq('id', data.user.id)
+        .then(({ error: e }) => e && console.warn('[Auth] last_login update:', e.message));
+      return { success: true, role: prof?.role };
     }
-
-    // 5. Create Session
-    const sessionUser = {
-      id: employee.id,
-      username: employee.username,
-      name: employee.name,
-      email: employee.email,
-      role: employee.role,
-      lastLogin: new Date().toISOString(),
-      permissions: employee.role === 'super_admin' ? ['all'] : ['limited'] 
-    };
-
-    // Store in localStorage for persistence
-    localStorage.setItem('crm_user', JSON.stringify(sessionUser));
-    
-    // Update State
-    setUser(sessionUser);
-    
-    logLoginAttempt({ username: cleanInput, status: 'Success' });
-    console.log(`[Auth] Login successful for ${sessionUser.name} (${sessionUser.role})`);
-    
-    return { success: true, role: employee.role };
+    return { success: true };
   };
 
-  const logout = () => {
-    console.log('[Auth] Logging out user');
-    localStorage.removeItem('crm_user');
-    setUser(null);
-    window.location.href = '/crm/login';
-  };
+  // Compose the `user` shape that the rest of the app expects.
+  // Old shape: { id, username, name, email, role, lastLogin, permissions }
+  const user = authUser && profile
+    ? {
+        id: profile.id,
+        username: profile.username,
+        name: profile.name,
+        email: profile.email || authUser.email,
+        role: profile.role,
+        phone: profile.phone,
+        department: profile.department,
+        permissions: profile.permissions || (profile.role === 'super_admin' ? ['all'] : ['limited']),
+        lastLogin: profile.last_login,
+      }
+    : null;
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, loading, isAuthenticated: !!user }}>
+    <AuthContext.Provider value={{ user, login, logout, loading, isAuthenticated: !!authUser }}>
       {!loading && children}
     </AuthContext.Provider>
   );

--- a/src/crm/hooks/useLeads.js
+++ b/src/crm/hooks/useLeads.js
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useAuth } from '@/context/AuthContext';
+
+const PAGE_SIZE = 50;
+
+// Columns covered by idx_leads_mypage_covering — querying these keeps the
+// fetch on an index-only scan and avoids pulling 53 columns × thousands of rows.
+const LIST_COLUMNS = [
+  'id',
+  'name',
+  'phone',
+  'status',
+  'final_status',
+  'interest_level',
+  'follow_up_date',
+  'follow_up_priority',
+  'project_name',
+  'is_vip',
+  'is_archived',
+  'is_active',
+  'created_at',
+  'updated_at',
+  'assigned_to',
+  'assigned_to_name',
+  'source',
+  'last_note',
+].join(',');
+
+/**
+ * useLeads
+ * ────────
+ * Paginated leads query against public.leads. Defaults to "my leads"
+ * (assigned_to = current user) but admins/managers can override via
+ * the `scope` option.
+ *
+ * Why this is fast on production data (4753 rows):
+ *  - Only fetches 18 columns (uses idx_leads_mypage_covering)
+ *  - LIMIT 50 + keyset pagination on updated_at, NOT OFFSET
+ *  - Filters server-side, not in JS
+ *
+ * Usage:
+ *   const { leads, loading, loadingMore, hasMore, loadMore, refetch,
+ *           total, search, setSearch, status, setStatus } = useLeads();
+ */
+export function useLeads({ scope = 'mine' } = {}) {
+  const { user } = useAuth();
+  const [leads, setLeads] = useState([]);
+  const [total, setTotal] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [error, setError] = useState(null);
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState('all');
+
+  // Anchor cursor for keyset pagination
+  const cursorRef = useRef(null); // { updated_at, id }
+  const reqIdRef = useRef(0);
+
+  const canSeeAll = ['super_admin', 'sales_manager', 'sub_admin', 'manager'].includes(user?.role);
+  const effectiveScope = scope === 'all' && canSeeAll ? 'all' : 'mine';
+
+  const buildBase = useCallback(() => {
+    let q = supabase.from('leads').select(LIST_COLUMNS, { count: 'exact' });
+
+    if (effectiveScope === 'mine' && user?.id) {
+      q = q.eq('assigned_to', user.id);
+    }
+    q = q.eq('is_archived', false);
+
+    if (status && status !== 'all') {
+      q = q.eq('status', status);
+    }
+    if (search?.trim()) {
+      const s = search.trim();
+      q = q.or(`name.ilike.%${s}%,phone.ilike.%${s}%`);
+    }
+    return q.order('updated_at', { ascending: false }).order('id', { ascending: false });
+  }, [effectiveScope, user?.id, status, search]);
+
+  const fetchInitial = useCallback(async () => {
+    if (!user) return;
+    const myReq = ++reqIdRef.current;
+    setLoading(true);
+    setError(null);
+    cursorRef.current = null;
+
+    const { data, count, error } = await buildBase().limit(PAGE_SIZE);
+    if (myReq !== reqIdRef.current) return;
+
+    if (error) {
+      setError(error);
+      setLeads([]);
+      setTotal(0);
+      setHasMore(false);
+    } else {
+      setLeads(data || []);
+      setTotal(count ?? null);
+      setHasMore((data?.length || 0) === PAGE_SIZE);
+      const last = data?.[data.length - 1];
+      cursorRef.current = last ? { updated_at: last.updated_at, id: last.id } : null;
+    }
+    setLoading(false);
+  }, [buildBase, user]);
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || loadingMore || !cursorRef.current) return;
+    setLoadingMore(true);
+    const cursor = cursorRef.current;
+    const myReq = reqIdRef.current;
+
+    // Keyset: rows whose (updated_at, id) sort AFTER the cursor in DESC order
+    let q = buildBase();
+    q = q.or(
+      `updated_at.lt.${cursor.updated_at},and(updated_at.eq.${cursor.updated_at},id.lt.${cursor.id})`,
+    );
+    const { data, error } = await q.limit(PAGE_SIZE);
+
+    if (myReq !== reqIdRef.current) {
+      setLoadingMore(false);
+      return;
+    }
+    if (error) {
+      setError(error);
+    } else if (data?.length) {
+      setLeads(prev => [...prev, ...data]);
+      const last = data[data.length - 1];
+      cursorRef.current = { updated_at: last.updated_at, id: last.id };
+      setHasMore(data.length === PAGE_SIZE);
+    } else {
+      setHasMore(false);
+    }
+    setLoadingMore(false);
+  }, [buildBase, hasMore, loadingMore]);
+
+  // Refetch on filter / user change
+  useEffect(() => {
+    fetchInitial();
+  }, [fetchInitial]);
+
+  // Lightweight mutation helpers — they update locally + persist to Supabase.
+  // The caller can `await` them; rejections bubble back as Error objects.
+  const updateLead = useCallback(async (id, patch) => {
+    setLeads(prev => prev.map(l => (l.id === id ? { ...l, ...patch } : l)));
+    const { data, error } = await supabase
+      .from('leads')
+      .update(patch)
+      .eq('id', id)
+      .select(LIST_COLUMNS)
+      .single();
+    if (error) {
+      // Roll back optimistic update on failure
+      fetchInitial();
+      throw error;
+    }
+    setLeads(prev => prev.map(l => (l.id === id ? { ...l, ...data } : l)));
+    return data;
+  }, [fetchInitial]);
+
+  const addLead = useCallback(async (payload) => {
+    const { data, error } = await supabase
+      .from('leads')
+      .insert(payload)
+      .select(LIST_COLUMNS)
+      .single();
+    if (error) throw error;
+    setLeads(prev => [data, ...prev]);
+    setTotal(t => (t ?? 0) + 1);
+    return data;
+  }, []);
+
+  return useMemo(
+    () => ({
+      leads,
+      total,
+      loading,
+      loadingMore,
+      hasMore,
+      error,
+      search,
+      setSearch,
+      status,
+      setStatus,
+      scope: effectiveScope,
+      canSeeAll,
+      loadMore,
+      refetch: fetchInitial,
+      updateLead,
+      addLead,
+    }),
+    [leads, total, loading, loadingMore, hasMore, error, search, status, effectiveScope, canSeeAll, loadMore, fetchInitial, updateLead, addLead],
+  );
+}

--- a/src/crm/hooks/useNewLeadNotifications.js
+++ b/src/crm/hooks/useNewLeadNotifications.js
@@ -4,7 +4,7 @@ import { supabase } from '@/lib/supabase';
 /**
  * useNewLeadNotifications
  * ───────────────────────
- * Subscribes to `INSERT` events on `crm_leads` via Supabase Realtime.
+ * Subscribes to `INSERT` events on `public.leads` via Supabase Realtime.
  * Fires a browser notification (if permission granted) and calls onNewLead
  * so the parent can refetch / show a toast / play a sound.
  *
@@ -31,10 +31,10 @@ export function useNewLeadNotifications(onNewLead) {
     document.addEventListener('visibilitychange', syncPerm);
 
     const channel = supabase
-      .channel('crm_leads_realtime')
+      .channel('leads_realtime')
       .on(
         'postgres_changes',
-        { event: 'INSERT', schema: 'public', table: 'crm_leads' },
+        { event: 'INSERT', schema: 'public', table: 'leads' },
         (payload) => {
           const lead = payload.new || {};
           cbRef.current?.(lead);

--- a/src/crm/pages/MyLeads.jsx
+++ b/src/crm/pages/MyLeads.jsx
@@ -1,151 +1,198 @@
-import React, { useMemo, useState } from 'react';
-import { useCRMData } from '@/crm/hooks/useCRMData';
+import React, { useMemo } from 'react';
 import { useAuth } from '@/context/AuthContext';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Search, Plus, Filter, Phone, MessageCircle } from 'lucide-react';
-import projects from '@/data/projects';
+import { Search, Plus, Phone, MessageCircle, Loader2 } from 'lucide-react';
+import { useLeads } from '@/crm/hooks/useLeads';
 import NotificationPermissionBanner from '@/crm/components/NotificationPermissionBanner';
 import { useFollowUpNotifications } from '@/crm/hooks/useFollowUpNotifications';
 import { useNewLeadNotifications } from '@/crm/hooks/useNewLeadNotifications';
 
-const MyLeads = () => {
+const STATUS_COLOR = {
+  Booked:   'bg-green-100 text-green-800',
+  FollowUp: 'bg-yellow-100 text-yellow-800',
+  Lost:     'bg-gray-100 text-gray-800',
+  Open:     'bg-blue-100 text-blue-800',
+};
+
+// Combine the live schema's separate date + time columns into an ISO timestamp
+// so the generic follow-up notification hook can schedule a setTimeout.
+function combineFollowUp(lead) {
+  if (!lead.follow_up_date) return null;
+  const time = lead.follow_up_time || '10:00:00';
+  return new Date(`${lead.follow_up_date}T${time}`).toISOString();
+}
+
+export default function MyLeads() {
   const { user } = useAuth();
-  const { leads, addLead } = useCRMData();
-  const [searchTerm, setSearchTerm] = useState('');
-  const [statusFilter, setStatusFilter] = useState('all');
-  const [projectFilter, setProjectFilter] = useState('all');
+  const {
+    leads,
+    total,
+    loading,
+    loadingMore,
+    hasMore,
+    error,
+    search,
+    setSearch,
+    status,
+    setStatus,
+    scope,
+    loadMore,
+    refetch,
+  } = useLeads({ scope: 'mine' });
 
-  const myLeads = leads.filter(l => l.assignedTo === user?.id);
-
-  // Telecaller alerts: reminders fire when next_follow_up_at is due; a
-  // notification fires when a new lead lands in crm_leads via Realtime.
-  // The follow-up hook expects { id, name, phone, nextFollowUpAt, status, quickNote }
-  // — map our snapshot's `followUpDate` / `lastNote` shape into that.
-  const leadsForReminders = useMemo(() =>
-    myLeads.map(l => ({
+  // Map the live `leads` row shape onto what the follow-up hook expects
+  const leadsForReminders = useMemo(
+    () => leads.map(l => ({
       id: l.id,
       name: l.name,
       phone: l.phone,
-      nextFollowUpAt: l.followUpDate ?? l.nextFollowUpAt ?? null,
+      nextFollowUpAt: combineFollowUp(l),
       status: l.status,
-      quickNote: l.notes?.[l.notes.length - 1]?.text,
+      quickNote: l.last_note,
     })),
-    [myLeads]
+    [leads],
   );
+
   useFollowUpNotifications(leadsForReminders);
-  useNewLeadNotifications();
-
-  const filteredLeads = myLeads.filter(l => {
-    const matchesSearch = l.name.toLowerCase().includes(searchTerm.toLowerCase()) || l.phone.includes(searchTerm);
-    const matchesStatus = statusFilter === 'all' || l.status === statusFilter;
-    const matchesProject = projectFilter === 'all' || l.project === projectFilter;
-    return matchesSearch && matchesStatus && matchesProject;
-  });
-
-  const getStatusColor = (status) => {
-    switch(status) {
-      case 'Booked': return 'bg-green-100 text-green-800';
-      case 'FollowUp': return 'bg-yellow-100 text-yellow-800';
-      case 'Lost': return 'bg-gray-100 text-gray-800';
-      default: return 'bg-red-100 text-red-800';
-    }
-  };
+  useNewLeadNotifications(() => refetch());
 
   return (
-    <div className="space-y-6 pb-20">
+    <div className="space-y-4 pb-20">
       <NotificationPermissionBanner />
-      <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-3 md:gap-4">
-         <div className="min-w-0">
-            <h1 className="text-2xl font-bold text-[#0F3A5F]">My Leads</h1>
-            <p className="text-sm text-gray-500">Manage and track your potential clients</p>
-         </div>
-         <Button className="w-full md:w-auto min-h-[44px]">
-           <Plus className="mr-2 h-4 w-4" /> Add New Lead
-         </Button>
+
+      <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-3">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-bold text-[#0F3A5F]">My Leads</h1>
+          <p className="text-sm text-gray-500">
+            {total !== null
+              ? <>Showing {leads.length} of <span className="font-medium">{total}</span> {scope === 'all' ? 'leads (all)' : 'leads assigned to you'}</>
+              : 'Loading…'}
+          </p>
+        </div>
+        <Button className="w-full md:w-auto min-h-[44px] bg-[#0F3A5F]">
+          <Plus className="mr-2 h-4 w-4" /> Add New Lead
+        </Button>
       </div>
 
       <Card>
-         <CardContent className="p-4 space-y-4">
-            <div className="flex flex-col md:flex-row gap-4">
-               <div className="flex-1 relative">
-                  <Search className="absolute left-3 top-2.5 h-4 w-4 text-gray-400" />
-                  <Input 
-                    placeholder="Search by name or phone..." 
-                    className="pl-10"
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                  />
-               </div>
-               <Select value={statusFilter} onValueChange={setStatusFilter}>
-                  <SelectTrigger className="w-[180px]"><SelectValue placeholder="Status" /></SelectTrigger>
-                  <SelectContent>
-                     <SelectItem value="all">All Status</SelectItem>
-                     <SelectItem value="Open">Open</SelectItem>
-                     <SelectItem value="FollowUp">Follow Up</SelectItem>
-                     <SelectItem value="Booked">Booked</SelectItem>
-                     <SelectItem value="Lost">Lost</SelectItem>
-                  </SelectContent>
-               </Select>
-               <Select value={projectFilter} onValueChange={setProjectFilter}>
-                  <SelectTrigger className="w-[180px]"><SelectValue placeholder="Project" /></SelectTrigger>
-                  <SelectContent>
-                     <SelectItem value="all">All Projects</SelectItem>
-                     {projects.map(p => <SelectItem key={p.id} value={p.name}>{p.name}</SelectItem>)}
-                  </SelectContent>
-               </Select>
+        <CardContent className="p-4 space-y-4">
+          <div className="flex flex-col md:flex-row gap-3">
+            <div className="flex-1 relative">
+              <Search className="absolute left-3 top-2.5 h-4 w-4 text-gray-400" />
+              <Input
+                placeholder="Search by name or phone…"
+                className="pl-10 min-h-[44px]"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
             </div>
+            <Select value={status} onValueChange={setStatus}>
+              <SelectTrigger className="md:w-[180px] min-h-[44px]"><SelectValue placeholder="Status" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Status</SelectItem>
+                <SelectItem value="Open">Open</SelectItem>
+                <SelectItem value="FollowUp">Follow Up</SelectItem>
+                <SelectItem value="Booked">Booked</SelectItem>
+                <SelectItem value="Lost">Lost</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
 
-            <div className="rounded-md border">
-               <Table>
-                  <TableHeader>
-                     <TableRow>
-                        <TableHead>Lead Name</TableHead>
-                        <TableHead>Project</TableHead>
-                        <TableHead>Status</TableHead>
-                        <TableHead>Last Contact</TableHead>
-                        <TableHead className="text-right">Actions</TableHead>
-                     </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                     {filteredLeads.map(lead => (
-                        <TableRow key={lead.id}>
-                           <TableCell>
-                              <div className="font-medium">{lead.name}</div>
-                              <div className="text-xs text-gray-500">{lead.phone}</div>
-                           </TableCell>
-                           <TableCell>{lead.project}</TableCell>
-                           <TableCell>
-                              <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(lead.status)}`}>
-                                 {lead.status}
-                              </span>
-                           </TableCell>
-                           <TableCell>
-                              {lead.lastActivity ? new Date(lead.lastActivity).toLocaleDateString() : 'Never'}
-                           </TableCell>
-                           <TableCell className="text-right space-x-2">
-                              <Button variant="ghost" size="icon" onClick={() => window.location.href=`tel:${lead.phone}`}>
-                                 <Phone className="h-4 w-4 text-blue-600" />
-                              </Button>
-                              <Button variant="ghost" size="icon" onClick={() => window.open(`https://wa.me/91${lead.phone.slice(-10)}`, '_blank')}>
-                                 <MessageCircle className="h-4 w-4 text-green-600" />
-                              </Button>
-                           </TableCell>
-                        </TableRow>
-                     ))}
-                     {filteredLeads.length === 0 && (
-                        <TableRow><TableCell colSpan={5} className="text-center py-8 text-gray-500">No leads found matching your filters.</TableCell></TableRow>
-                     )}
-                  </TableBody>
-               </Table>
+          {error && (
+            <div className="text-sm text-rose-700 bg-rose-50 border border-rose-200 rounded-lg px-3 py-2">
+              Failed to load leads: {error.message}
             </div>
-         </CardContent>
+          )}
+
+          <div className="rounded-md border overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Lead Name</TableHead>
+                  <TableHead className="hidden sm:table-cell">Project</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="hidden md:table-cell">Last Updated</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {loading ? (
+                  <TableRow><TableCell colSpan={5} className="text-center py-12 text-gray-400">
+                    <Loader2 className="h-5 w-5 animate-spin inline-block mr-2" /> Loading leads…
+                  </TableCell></TableRow>
+                ) : leads.length === 0 ? (
+                  <TableRow><TableCell colSpan={5} className="text-center py-12 text-gray-400">
+                    No leads found{search ? ` for "${search}"` : ''}.
+                  </TableCell></TableRow>
+                ) : (
+                  leads.map(lead => (
+                    <TableRow key={lead.id}>
+                      <TableCell>
+                        <div className="font-medium">{lead.name}</div>
+                        <div className="text-xs text-gray-500">{lead.phone}</div>
+                      </TableCell>
+                      <TableCell className="hidden sm:table-cell">{lead.project_name || '—'}</TableCell>
+                      <TableCell>
+                        <span className={`px-2 py-1 rounded-full text-xs font-medium ${STATUS_COLOR[lead.status] || 'bg-gray-100 text-gray-700'}`}>
+                          {lead.status || '—'}
+                        </span>
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell text-xs text-gray-500">
+                        {lead.updated_at ? new Date(lead.updated_at).toLocaleDateString() : '—'}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="inline-flex gap-1">
+                          <Button
+                            variant="ghost" size="icon"
+                            className="h-10 w-10"
+                            onClick={() => { if (lead.phone) window.location.href = `tel:${lead.phone}`; }}
+                            aria-label="Call"
+                          >
+                            <Phone className="h-4 w-4 text-blue-600" />
+                          </Button>
+                          <Button
+                            variant="ghost" size="icon"
+                            className="h-10 w-10"
+                            onClick={() => {
+                              if (!lead.phone) return;
+                              const tail = String(lead.phone).replace(/\D/g, '').slice(-10);
+                              window.open(`https://wa.me/91${tail}`, '_blank', 'noopener');
+                            }}
+                            aria-label="WhatsApp"
+                          >
+                            <MessageCircle className="h-4 w-4 text-green-600" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          {hasMore && !loading && (
+            <div className="flex justify-center pt-2">
+              <Button
+                variant="outline"
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="min-h-[44px] w-full md:w-auto"
+              >
+                {loadingMore ? (
+                  <><Loader2 className="h-4 w-4 animate-spin mr-2" /> Loading…</>
+                ) : (
+                  <>Load 50 more</>
+                )}
+              </Button>
+            </div>
+          )}
+        </CardContent>
       </Card>
     </div>
   );
-};
-
-export default MyLeads;
+}

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,16 +1,22 @@
-// STUB — replaced by the real Supabase client in production.
-//
-// The production CRM repo defines this module as:
-//
-//   import { createClient } from '@supabase/supabase-js';
-//   export const supabase = createClient(
-//     import.meta.env.VITE_SUPABASE_URL,
-//     import.meta.env.VITE_SUPABASE_ANON_KEY
-//   );
-//
-// In THIS branch (the `crm-real-source` snapshot) the data layer is the
-// static files in `src/crm/data/`, so we expose a null client. Hooks that
-// depend on supabase (e.g. useNewLeadNotifications) gracefully no-op when
-// `supabase` is null.
+import { createClient } from '@supabase/supabase-js';
 
-export const supabase = null;
+// Anon key is public by design — Supabase RLS gates access. Hardcoded
+// fallbacks let Vercel preview builds work even before env vars are set.
+// Override with VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY for local dev
+// or to rotate keys without code changes.
+const SUPABASE_URL =
+  import.meta.env.VITE_SUPABASE_URL ||
+  'https://mfgjzkaabyltscgrkhdz.supabase.co';
+
+const SUPABASE_ANON_KEY =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1mZ2p6a2FhYnlsdHNjZ3JraGR6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzEzNDAzNjQsImV4cCI6MjA4NjkxNjM2NH0.V6uWBH72rgp0UEFdB9aT8qrG4YFYhnERWZO1t976_tM';
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: {
+    persistSession: true,
+    storageKey: 'fanbe-crm-auth',
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+  },
+});

--- a/supabase-perf-migration.sql
+++ b/supabase-perf-migration.sql
@@ -1,0 +1,74 @@
+-- ─────────────────────────────────────────────────────────────────────────
+-- Fanbe-CRM RLS performance + security migration
+-- ─────────────────────────────────────────────────────────────────────────
+-- NOT yet applied. Run this in Supabase SQL editor after confirming a
+-- recent backup. Expected impact: 5–10× faster leads queries against the
+-- 4753-row `public.leads` table, and closes a real security hole.
+--
+-- WHY each change is here:
+--
+--   (1) The `Allow all access to *` policies grant `qual=true` to role
+--       `public`. That means anyone with the publishable/anon key can
+--       SELECT / INSERT / UPDATE / DELETE every row in those tables.
+--       This bypasses RLS entirely AND adds eval cost on every query
+--       because PostgreSQL still checks all permissive policies.
+--
+--   (2) The "Employees can ..." policies on leads duplicate the
+--       `leads_*_by_role` policies but target role `public` and call
+--       `auth.uid()` per row. Drop them — coverage is already provided
+--       by `leads_*_by_role` which target `authenticated`.
+--
+--   (3) The `leads_*_by_role` policies call `auth.uid()` per row. Wrap
+--       in `(select auth.uid())` so PostgreSQL evaluates once per
+--       statement instead of once per row. See:
+--       https://supabase.com/docs/guides/database/postgres/row-level-security#call-functions-with-select
+--
+-- ─────────────────────────────────────────────────────────────────────────
+
+BEGIN;
+
+-- (1) Drop wide-open policies on 6 tables
+DROP POLICY IF EXISTS "Allow all access to leads"            ON public.leads;
+DROP POLICY IF EXISTS "Allow all access to calls"            ON public.calls;
+DROP POLICY IF EXISTS "Allow all access to site_visits"      ON public.site_visits;
+DROP POLICY IF EXISTS "Allow all access to bookings"         ON public.bookings;
+DROP POLICY IF EXISTS "Allow all access to tasks"            ON public.tasks;
+DROP POLICY IF EXISTS "Allow all access to bp_payment_queue" ON public.bp_payment_queue;
+
+-- (2) Drop the redundant `public`-role employee policies on leads
+DROP POLICY IF EXISTS "Employees can create manual leads"        ON public.leads;
+DROP POLICY IF EXISTS "Employees can update their assigned leads" ON public.leads;
+
+-- (3) Refactor remaining `leads` policies for per-statement uid()
+ALTER POLICY leads_select_by_role ON public.leads
+  USING (
+    is_super_admin() OR is_sales_manager()
+    OR (assigned_to = (SELECT auth.uid()))
+    OR (created_by  = (SELECT auth.uid()))
+  );
+
+ALTER POLICY leads_update_by_role ON public.leads
+  USING (
+    is_super_admin() OR is_sales_manager()
+    OR (assigned_to = (SELECT auth.uid()))
+    OR (created_by  = (SELECT auth.uid()))
+  )
+  WITH CHECK (
+    is_super_admin() OR is_sales_manager()
+    OR (assigned_to = (SELECT auth.uid()))
+    OR (created_by  = (SELECT auth.uid()))
+  );
+
+ALTER POLICY leads_insert_by_role ON public.leads
+  WITH CHECK (
+    is_super_admin() OR is_sales_manager()
+    OR (is_sales_executive()
+        AND created_by = (SELECT auth.uid())
+        AND (assigned_to = (SELECT auth.uid()) OR assigned_to IS NULL))
+  );
+
+COMMIT;
+
+-- After running, re-run `supabase advisors` to confirm the
+-- `multiple_permissive_policies` count drops and the `auth_rls_initplan`
+-- warnings on `leads` are resolved.


### PR DESCRIPTION
## TL;DR

Reverse-engineers the live `fanbegroup.com/crm/sales/crm` CRM enough to **wire real Supabase auth and a fast, paginated leads query**. Ships a separate SQL migration that fixes the worst RLS perf issues + closes a real security hole. Use the **Vercel preview** of this PR to verify before promoting — your existing production at `fanbegroup.com` is untouched.

## What I dug up in your DB tonight

| Finding | Detail |
|---|---|
| **Live table** | `public.leads` (4,753 rows, 53 columns), NOT `crm_leads` (0 rows — that's the empty demo table I wired into PR #88) |
| **Why leads load slow** | Compiled bundle does `SELECT *` + no pagination → ~5–10 MB payload + 4,753 rows in DOM |
| **Indexes already in place** | 25 indexes including `idx_leads_mypage_covering` — perfect match for the columns this UI needs |
| **🚨 Security hole** | Six tables (`leads`, `calls`, `site_visits`, `bookings`, `tasks`, `bp_payment_queue`) have an `Allow all access to *` policy with `qual=true` granted to role `public`. Anyone with the anon key has full CRUD. |
| **RLS perf** | 5 policies on `leads` call `auth.uid()` per row instead of `(select auth.uid())` per statement — the Supabase `auth_rls_initplan` lint flags all of them |

## Changes in this PR

### Code

- **`src/lib/supabase.js`** — real `createClient(...)` with persisted session. Hardcoded fallbacks for `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` so the build works in any environment.
- **`src/context/AuthContext.jsx`** — full rewrite. localStorage flow → real `supabase.auth`. Login takes username OR email; usernames are resolved via a single `profiles.username → email` lookup. Loads role + name + permissions from `profiles` so `useAuth()` returns the same `user` shape as before.
- **`src/crm/hooks/useLeads.js`** (new) — paginated query against `public.leads`. Selects 18 columns (matches the covering index). Role-aware scoping (admins/managers see all, others see own). Server-side status + name/phone search. Keyset pagination with `LIMIT 50` + Load-more button.
- **`src/crm/hooks/useNewLeadNotifications.js`** — points at `public.leads` (was `crm_leads`, which is empty).
- **`src/crm/pages/MyLeads.jsx`** — uses `useLeads`. Maps `follow_up_date` + `follow_up_time` → ISO for `useFollowUpNotifications`. Adds banner + ≥44px touch targets.
- **`package.json`** — adds `@supabase/supabase-js@^2.45.0`.
- **`.env.example`** — documents env vars.

### Database (NOT applied — needs your approval)

**`supabase-perf-migration.sql`** at repo root. Drops the 6 wide-open `Allow all access to *` policies, drops 2 duplicate employee policies on `leads`, refactors remaining `leads_*_by_role` policies to wrap `auth.uid()` in `(select auth.uid())`.

**Expected impact:** 5–10× faster leads queries + closes the anon-CRUD hole. **Risk:** if any external script / cron / Zapier webhook authenticates with the anon key and relies on it for write access, it'll start getting `permission denied`. If everything goes through authenticated sessions, this is safe. **Take a Supabase backup before applying.**

To apply: open Supabase → SQL Editor → paste the contents → run.

## Build

```
$ npm install
added 8 packages in 4s

$ npm run build
✓ 3043 modules transformed.
dist/assets/index-Da4cA4bC.css 83.90 kB │ gzip:  13.62 kB
dist/assets/index-7vnsRxfm.js  2,343.78 kB │ gzip: 673.50 kB
✓ built in 14.57s
```

## Test plan (Vercel preview)

- [ ] Open the preview URL Vercel posts on this PR
- [ ] Visit `/crm/login` → log in with a **real production user** (e.g. `beena@fanbegroup.com` + her actual password from auth.users, OR her username if `profiles.username = 'beena'`). The localStorage seeded demo accounts no longer work — this is real Supabase auth now.
- [ ] On `/crm/sales/my-leads`: **initial fetch should be fast** (≤1 sec for 50 rows vs 5+ sec for 4753)
- [ ] Scroll to bottom → **Load 50 more** appears → clicking it appends the next page without reloading
- [ ] **Search** "beena" or a phone number → server-side filter kicks in
- [ ] **Status filter** dropdown → server-side filter
- [ ] Notification permission banner appears at top → Enable → granted
- [ ] (manual) `INSERT INTO public.leads (...)` from Supabase SQL editor → notification fires in the open browser tab

## What's NOT in this PR (next sessions)

- Migrating `useCRMData` for admin/HR/sub-admin pages (they still hit static localStorage data)
- Role-based route gating using `profile.role` (super_admin / sales_manager / sub_admin / sales_executive / manager / telecaller)
- Replacing the production compiled bundle with this Vite build (separate Vercel "Promote to Production" or DNS decision — your call)
- Smart Quick Note panel wiring into the live `leads` table mutations (currently the modal's `onAddNote` still writes to localStorage)

## What I need from you when you wake up

1. **Test the preview**. Confirm log-in works with a real Supabase user. Confirm leads load fast and paginate.
2. **Decide on the DB migration.** Reply with "apply migration" if you want me to run `supabase-perf-migration.sql` against production. I'll **not** apply it without your explicit go-ahead.
3. **Decide on production cutover.** Once the preview is verified, you choose whether to promote this Vite build to production (replaces the compiled bundle) or stay on the existing bundle for now.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_