### PR TITLE
hotfix(prod): SPA fallback vercel.json + /crm/sales/crm route alias

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -192,6 +192,12 @@ const AppRoutes = ({ onBookSiteVisit }) => {
 
                    {/* Sales Routes */}
                    <Route path="sales/dashboard" element={<SalesExecutiveDashboard />} />
+                   {/* `sales/crm` is the production telecaller URL
+                       (fanbegroup.com/crm/sales/crm). Alias to MyLeads so the
+                       live link doesn't 404 — MyLeads is also where the new
+                       Supabase-powered paginated list + smart quick-note +
+                       notifications are wired. */}
+                   <Route path="sales/crm" element={<MyLeads />} />
                    {/* Fallback to desktop dash if not mobile */}
                    {!isMobile && <Route path="employee-dashboard" element={<EmployeeDashboard />} />}
                    

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Why prod is 404'ing right now

You did "Production Rebuild" of the `crm/horizons-live-source` build (the merge of PR #91). That branch is missing two pieces that were on the **closed PR #89** against `crm-real-source` — I closed #89 thinking we'd revert, so the fixes never landed here.

### What's missing

1. **No `vercel.json`** → Vercel currently serves `dist/` as static files and returns 404 for any path that isn't a built file. The Vite app's React Router never gets a chance to handle the URL. The `404: NOT_FOUND` from `bom1::jzgqt-…` in your screenshot is Vercel's edge 404, not a React 404.

2. **No `/crm/sales/crm` route in `App.jsx`** → even with SPA fallback in place, React Router has no entry for that URL and would land on the catch-all.

### Fix in this PR

**`vercel.json`** (new):
```json
{ "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }] }
```

**`src/App.jsx`** (one new route line):
```jsx
<Route path="sales/crm" element={<MyLeads />} />
```

Mapping `sales/crm` to `<MyLeads />` is deliberate — that's the page where PR #91's real Supabase auth + paginated `useLeads` + notification banner + smart-quick-note are wired. So when you land on `fanbegroup.com/crm/sales/crm` you'll see the fast, paginated, modern list.

## Build

```
$ npm run build
✓ 3043 modules transformed.
dist/index.html                3.01 kB │ gzip:   0.97 kB
dist/assets/index-Da4cA4bC.css 83.90 kB │ gzip:  13.62 kB
dist/assets/index-DetNMm13.js  2,343.83 kB │ gzip: 673.50 kB
✓ built in 15.41s
```

## What you do after merging

1. **Promote the new production deployment.** When this merges, Vercel automatically deploys `crm/horizons-live-source`. Once that deployment is Ready, go to Deployments → click `…` on the new one → **Promote to Production**. Or "Production Rebuild" — same effect.
2. **Verify** `fanbegroup.com/crm/sales/crm` → should now load MyLeads (paginated, with notification banner at top), not 404.
3. **Log in with a real Supabase user.** The localStorage-seeded `admin / Admin@2026!Secure` demo accounts no longer work — this build uses real `supabase.auth`. Use the credentials of whichever user exists in `public.profiles` + `auth.users` (Beena, your admin account, etc.).

## Still pending from PR #91 (when you're ready)

- Apply `supabase-perf-migration.sql` to fix the wide-open `Allow all access to *` policies + RLS perf — sitting at the repo root waiting for your "apply migration" go-ahead

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_