### PR TITLE
chore(crm): rename "Call CRM" → "My CRM" in employee bottom-nav

### DIFF
--- a/scripts/copy-main-website.mjs
+++ b/scripts/copy-main-website.mjs
@@ -26,20 +26,26 @@ function copyRecursive(src, dest) {
 copyRecursive(SRC, DEST)
 console.log('✅ Main website files copied into dist/')
 
-// Sidebar nav label patch in the compiled admin CRM bundle: "Dashboard" → "Control".
+// Compiled CRM bundle label patches.
+//   - "Dashboard" → "Control" in the admin sidebar
+//   - "Call CRM" → "My CRM" in the employee bottom-nav (covers all 3 string
+//     forms in the bundle: emoji label, plain label, and page header text)
 const assetsDir = path.join(DEST, 'assets')
 if (existsSync(assetsDir)) {
   for (const file of readdirSync(assetsDir)) {
     if (!file.endsWith('.js')) continue
     const filePath = path.join(assetsDir, file)
     const content = readFileSync(filePath, 'utf8')
-    const patched = content.replaceAll(
-      'label:"Dashboard",path:"/crm/admin/dashboard"',
-      'label:"Control",path:"/crm/admin/dashboard"'
-    )
+    const patched = content
+      .replaceAll(
+        'label:"Dashboard",path:"/crm/admin/dashboard"',
+        'label:"Control",path:"/crm/admin/dashboard"'
+      )
+      .replaceAll('"📞 Call CRM"', '"📞 My CRM"')
+      .replaceAll('"Call CRM"', '"My CRM"')
     if (patched !== content) {
       writeFileSync(filePath, patched, 'utf8')
-      console.log(`🔧 Patched sidebar label: Dashboard → Control in ${file}`)
+      console.log(`🔧 Patched labels (Dashboard → Control, Call CRM → My CRM) in ${file}`)
     }
   }
 }


### PR DESCRIPTION
## What this does

Renames the employee bottom-nav label **"📞 Call CRM" → "📞 My CRM"** in the deployed CRM bundle. Live within ~2 min of merge once Vercel rebuilds.

## How

Adds two lines to the existing `scripts/copy-main-website.mjs` bundle-patch loop — the same script that already does `Dashboard → Control` on every Vercel build:

```js
.replaceAll('"📞 Call CRM"', '"📞 My CRM"')   // emoji form (2 places)
.replaceAll('"Call CRM"',     '"My CRM"')      // plain label + page header (2 places)
```

Order matters: emoji form first, otherwise the substring won't match cleanly.

## Verified locally

Active bundle `index-CEzJ4Bo2-1776612329727-ttzx17.js`:

| String | Before | After |
|---|---|---|
| `"📞 Call CRM"` | 2 | 0 |
| `"Call CRM"` | 2 | 0 |
| `"📞 My CRM"` | 0 | 2 |
| `"My CRM"` | 0 | 2 |

The 4 affected sites in the bundle:
- SALES_EXECUTIVE role nav config
- TELECALLER role nav config
- Nav tab definition (`id:"crm",label:"My CRM"`)
- Page header (`children:"My CRM"`)

## What this does NOT do

This PR only renames text. The two larger asks from the same conversation —

- **Smarter quick notes** (auto-detect "call back tomorrow" → set follow-up; auto-tag intent)
- **Auto browser notifications** when follow-up time arrives

— are **not in this PR**. They require source-level changes to the actual production React app, and that source isn't currently in this repo on either `main` (deleted in PR #87, the `kill the /sales/ Vite app` cleanup) or the `crm/horizons-live-source` branch (which is a stripped-down reconstruction missing many production features like the Call Now/Follow Up/All tabs, mobile lead cards, and pagination).

Tracking those separately — they need source recovery first, then they're real PRs.

## Risk

Near-zero. Bundle-patch only, no source changes, mirrors a pattern that's already in production. If wrong, revert is a one-line edit.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_