### PR TITLE
hotfix(auth): don't block CRM on Supabase session timeout (4s → 15s + graceful fallback)

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -32,7 +32,7 @@ const AuthContext = createContext(null);
 // Survives React re-renders and prevents double DB call
 const _profileCache = new Map();
 
-const getSessionWithTimeout = (ms = 4000) => {
+const getSessionWithTimeout = (ms = 15000) => {
   const sessionPromise = supabase.auth.getSession();
   const timeoutPromise = new Promise((resolve) =>
     setTimeout(() => resolve({ data: { session: null }, error: new Error('timeout') }), ms)
@@ -59,14 +59,18 @@ export const AuthProvider = ({ children }) => {
   useEffect(() => {
     let isMounted = true;
 
-    // ── Step 1: check existing session (4s timeout) ─────────────────────
-    getSessionWithTimeout(4000).then(async ({ data: { session }, error }) => {
+    // ── Step 1: check existing session (15s timeout) ────────────────────
+    getSessionWithTimeout(15000).then(async ({ data: { session }, error }) => {
       if (!isMounted) return;
 
       if (error?.message === 'timeout') {
-        console.warn('[Auth] Supabase timed out — cannot reach server');
-        setConnectionError(true);
+        // Supabase didn't respond in 15s — likely slow network, NOT a paused
+        // project. Don't block the app on this. Treat as "no session" and
+        // let the user land on /login normally; AuthStateChange will pick
+        // them up once the SDK eventually resolves.
+        console.warn('[Auth] Supabase getSession timed out after 15s — continuing with no session');
         setLoading(false);
+        initializeData();
         return;
       }
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -120,7 +120,7 @@ export const AuthProvider = ({ children }) => {
           if (userRef.current) return; // already have user — skip
         }
 
-        if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+        if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'INITIAL_SESSION') {
           const uid = session.user.id;
           try {
             // FIX: use cache — SIGNED_IN fires right after getSessionWithTimeout


### PR DESCRIPTION
## 🚨 Production hotfix

After PR #95 (source restore + Vite build pipeline) landed, employees opening `fanbegroup.com/crm/sales/crm` see the full-screen **"Cannot connect to server / The database is unreachable"** error instead of the CRM.

**Supabase project status: `ACTIVE_HEALTHY`** (verified via MCP — DB is fine, NOT paused).

## Root cause

`src/context/AuthContext.jsx::getSessionWithTimeout()` races `supabase.auth.getSession()` against a **4-second timeout**. If the SDK doesn't resolve in 4s — which happens on a cold load over slow mobile network — `connectionError` is set, hiding the entire CRM behind the error screen with no off-ramp except "Retry".

Why this didn't bite before: the pre-PR-#95 bundle was cached in user browsers for days, so the auth session was warm. With PR #95 we shipped a fresh bundle (new chunk hashes), so every user is on a cold load, and the 4s timeout is firing on real-world mobile networks.

## Two changes

1. **Bump timeout 4000ms → 15000ms.** Still well under "feels broken" territory, but generous enough for Indian 5G cold-load + Supabase session round-trip.
2. **On timeout, don't block.** Instead of setting `connectionError`, log a warning and continue with `session: null`. The user lands on the normal flow; the `onAuthStateChange` subscription set up in step 2 still picks them up if Supabase eventually responds — no manual reload required.

The error screen (lines 187-213) is kept for the actual case where Supabase returns a real error other than timeout.

## Verification

Local build: 3089 modules, 11.64s, ✓ no errors. Bundle size unchanged (1.21 MB index chunk, same vendor splits).

## What to do once this is merged

1. Wait ~2 min for Vercel to redeploy
2. Hard-refresh `fanbegroup.com/crm/sales/crm` on the employee phone (Ctrl+Shift+R or pull-to-refresh + reopen tab)
3. Should land on the CRM normally. If the SDK is still slow, you'll briefly see the "Loading…" splash (15s max) instead of the error screen, then the CRM appears.

## If THIS doesn't help

The Vercel build for PR #95 may have failed (I can't access Vercel API from this session — `team_7WFlFGqBc9QtzLjUokZXN94L` returns 403). Check `vercel.com/.../deployments` for build status.

**Rollback path:** revert merge commit `107cd8e` (PR #95). That restores the pre-Vite-build state where `main-website/` is served directly. `main-website/` is still in the repo for exactly this case.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_