### PR TITLE
🚨 hotfix(realtime): unique channel names per mount — fixes admin dashboard crash

### DIFF
--- a/src/crm/hooks/useCRMData.js
+++ b/src/crm/hooks/useCRMData.js
@@ -12,7 +12,7 @@
 //        a duplicate fetchLeads() on initial page load (Chromium fires the event
 //        immediately when the page first becomes visible, which previously caused
 //        req#1 and req#2 to both apply 2084 leads and trigger a 300ms forced reflow).
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useId } from 'react';
 import { supabaseAdmin } from '@/lib/supabase';
 import { addCall, getCalls, addSiteVisit, getSiteVisits, addBooking, getBookings } from '@/lib/crmSupabase';
 import {
@@ -93,24 +93,32 @@ export const useCRMData = () => {
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   // ✅ SUPABASE REALTIME SUBSCRIPTIONS
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  // Append a per-mount unique suffix to every channel name. The Supabase
+  // JS client caches channels by name internally — if a component re-mounts
+  // (admin nav, hot-reload, etc.) and tries to create a channel with the
+  // same static name as before, the SDK returns the existing already-
+  // subscribed channel and `.on('postgres_changes', ...)` throws
+  // "cannot add postgres_changes callbacks for ... after subscribe()".
+  // Unique names per mount eliminate that collision entirely.
+  const channelSuffix = useId().replace(/:/g, '');
   useEffect(() => {
     const leadsChannel = supabaseAdmin
-      .channel('realtime:leads')
+      .channel(`realtime:leads:${channelSuffix}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'leads' }, () => fetchLeads())
       .subscribe();
 
     const visitsChannel = supabaseAdmin
-      .channel('realtime:site_visits')
+      .channel(`realtime:site_visits:${channelSuffix}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'site_visits' }, () => fetchSiteVisits())
       .subscribe();
 
     const callsChannel = supabaseAdmin
-      .channel('realtime:calls')
+      .channel(`realtime:calls:${channelSuffix}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'calls' }, () => fetchCalls())
       .subscribe();
 
     const bookingsChannel = supabaseAdmin
-      .channel('realtime:bookings')
+      .channel(`realtime:bookings:${channelSuffix}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'bookings' }, () => fetchBookings())
       .subscribe();
 


### PR DESCRIPTION
## 🚨 Production hotfix — admin dashboard crashing

`/crm/admin/dashboard` throws and renders "Something went wrong":

```
Error: cannot add 'postgres_changes' callbacks for
       realtime:realtime:leads after 'subscribe()'
```

## Root cause

`useCRMData.js` created realtime channels with **static names** (`realtime:leads`, `realtime:site_visits`, `realtime:calls`, `realtime:bookings`). The Supabase JS client caches channels by name internally. On any remount of the admin layout — route change, navigation back, hot-reload — the `.channel('realtime:leads')` call returns the cached already-subscribed instance, and the subsequent `.on('postgres_changes', ...)` throws.

Worked in the pre-PR-#98 bundle because that was compiled against an older `@supabase/supabase-js` where channel name caching was looser. Vercel's `vite build` from source now resolves `^2.45.0` to a current 2.x that enforces this strictly.

## Fix

Append a per-mount unique suffix via React 18's `useId()`:

```diff
-    .channel('realtime:leads')
+    .channel(`realtime:leads:${channelSuffix}`)
```

Each `useCRMData()` invocation gets its own namespace. Name collisions can't happen anymore. `removeChannel()` in the cleanup still works because it operates by channel reference, not name.

## Files

| File | Change |
|---|---|
| `src/crm/hooks/useCRMData.js` | Add `useId` import; suffix all 4 channel names |

13 insertions, 5 deletions. Nothing else touched.

## Rollback

Single revert. Production goes back to the broken state — but `main-website/` is **gone** now (you deleted it), so there's no "old bundle fallback" anymore. If this hotfix doesn't help, the next-level rollback is reverting PR #98 itself, which means also restoring `main-website/`. Plan accordingly.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_