### PR TITLE
feat(marketing): render Header on public site — adds Admin Login button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -252,24 +252,27 @@ const AppRoutes = ({ onBookSiteVisit }) => {
   }
 
   return (
-    <AnimatePresence mode="wait">
-      <Routes location={location} key={location.pathname}>
-        <Route path="/" element={<HomePage onBookSiteVisit={onBookSiteVisit} />} />
-        <Route path="/about" element={<AboutPage />} />
-        <Route path="/projects" element={<ProjectsListingPage />} />
-        <Route path="/projects/:slug" element={<ProjectDetailPage />} />
-        <Route path="/why-invest" element={<WhyInvestPage />} />
-        <Route path="/contact" element={<ContactPage />} />
-        <Route path="/broker/login" element={<BrokerLoginPage />} />
-        <Route path="/broker/register" element={<BrokerRegisterPage />} />
-        <Route path="/broker/portal" element={
-          <BrokerProtectedRoute>
-            <BrokerPayoutPortalPage />
-          </BrokerProtectedRoute>
-        } />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
-    </AnimatePresence>
+    <>
+      <Header onBookSiteVisit={onBookSiteVisit} />
+      <AnimatePresence mode="wait">
+        <Routes location={location} key={location.pathname}>
+          <Route path="/" element={<HomePage onBookSiteVisit={onBookSiteVisit} />} />
+          <Route path="/about" element={<AboutPage />} />
+          <Route path="/projects" element={<ProjectsListingPage />} />
+          <Route path="/projects/:slug" element={<ProjectDetailPage />} />
+          <Route path="/why-invest" element={<WhyInvestPage />} />
+          <Route path="/contact" element={<ContactPage />} />
+          <Route path="/broker/login" element={<BrokerLoginPage />} />
+          <Route path="/broker/register" element={<BrokerRegisterPage />} />
+          <Route path="/broker/portal" element={
+            <BrokerProtectedRoute>
+              <BrokerPayoutPortalPage />
+            </BrokerProtectedRoute>
+          } />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </AnimatePresence>
+    </>
   );
 };
 


### PR DESCRIPTION
## What

Adds the top nav header (with **"Admin Login"** button → `/crm/login`) to the public marketing site at `fanbegroup.com/` and the other public routes (/about, /projects, /why-invest, /contact, /broker/*).

## Why

`Header.jsx` was imported in `App.jsx` but **never actually rendered**, so the marketing site had no top nav at all. You had to know to type `/crm/login` manually — no UI affordance.

## Change

One-block edit in `src/App.jsx`:

```diff
   return (
-    <AnimatePresence mode="wait">
-      <Routes ...>
+    <>
+      <Header onBookSiteVisit={onBookSiteVisit} />
+      <AnimatePresence mode="wait">
+        <Routes ...>
           ...
-      </Routes>
-    </AnimatePresence>
+        </Routes>
+      </AnimatePresence>
+    </>
   );
```

## What you'll see after deploy

- Top of `fanbegroup.com/` and every public page: navigation bar with Home / About / Projects / Why Invest / Contact / Broker links
- **"Admin Login"** button (top right desktop, hamburger menu mobile) → one tap to `/crm/login`
- "Book Site Visit" CTA wired up

## What's NOT affected

CRM routes (`/crm/*`) — they have their own `CRMTopNav` + sidebar inside `CRMLayout` and don't go through this code path. Zero change to employee/admin CRM screens.

## Risk

Near-zero. Header.jsx is mature, already in the bundle (just unused), already styled. Worst case: header looks off and you revert this one commit.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_