### PR TITLE
chore(ux): suppress booking social-proof toast inside the CRM

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -278,6 +278,11 @@ const AppRoutes = ({ onBookSiteVisit }) => {
 
 function App() {
   const [showSiteVisitModal, setShowSiteVisitModal] = useState(false);
+  // Booking social-proof toast is a public-marketing nudge — suppress it
+  // on /crm/* so employees don't see "X just booked!" pop-ups while they
+  // are working their lead list.
+  const { pathname } = useLocation();
+  const isCRM = pathname.startsWith('/crm');
   return (
     <>
       <ScrollToTop />
@@ -287,7 +292,7 @@ function App() {
         onClose={() => setShowSiteVisitModal(false)}
       />
       <FloatingWhatsAppButton />
-      <SocialProofToast />
+      {!isCRM && <SocialProofToast />}
       <Toaster />
     </>
   );


### PR DESCRIPTION
## Why

The booking social-proof toast (e.g. *"लता देवी जी, मुरादाबाद से — बुकिंग हुई · 60 गज · ₹9.31L"*) makes sense on the public marketing site as a FOMO nudge for prospective buyers, but it's just noise inside the CRM where employees are working their lead list.

## Fix

In `App()`, use `useLocation()` to gate `<SocialProofToast/>` so it doesn't render on any `/crm/*` route:

```diff
+ const { pathname } = useLocation();
+ const isCRM = pathname.startsWith('/crm');
  ...
- <SocialProofToast />
+ {!isCRM && <SocialProofToast />}
```

6 inserts, 1 delete. Single file.

## What this does NOT touch

- `<FloatingWhatsAppButton/>` (the green "Chat with us" floating button) — left as-is in CRM. If that's also unwanted in the CRM, easy follow-up to gate the same way.
- Toast still works normally on `fanbegroup.com/`, `/about`, `/projects`, `/contact`, etc.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_