### PR TITLE
feat(crm): show budget chip on My Leads page lead cards

### DIFF
--- a/src/crm/pages/MyLeads.jsx
+++ b/src/crm/pages/MyLeads.jsx
@@ -579,6 +579,13 @@ const MyLeads = () => {
                                 {isTD&&!isOD && <span style={{ fontSize:10,fontWeight:800,color:'#D97706',background:'#FFFBEB',padding:'2px 6px',borderRadius:999,flexShrink:0 }}>⏰</span>}
                               </div>
                               {lead.project && <div style={S.project}>🏢 {lead.project}</div>}
+                              {(lead.budget || lead.budget_range) && (
+                                <div style={{ fontSize:11, fontWeight:700, color:'#92400E', background:'#FEF3C7', padding:'2px 8px', borderRadius:6, display:'inline-block', marginTop:2 }}>
+                                  💰 {typeof (lead.budget || lead.budget_range) === 'number'
+                                    ? `₹${Number(lead.budget || lead.budget_range).toLocaleString('en-IN')}`
+                                    : (lead.budget || lead.budget_range)}
+                                </div>
+                              )}
                               <div style={S.metaRow}>
                                 {lead.phone && <span style={S.phone}>{formatPhone(lead.phone)}</span>}
                                 {fuDate && <span style={S.fuChip(urgency)}>📅 {format(fuDate,'dd MMM')}</span>}


### PR DESCRIPTION
## Why

Follow-up to PR #103. You confirmed budget chips help on `/crm/sales/crm` (the dashboard), and asked for them on **`/crm/sales/my-leads`** as well so telecallers see budget right on the list view.

## What

Adds the same budget chip to the active lead-card variant in `MyLeads.jsx` (line ~572+, the one currently rendered in production with the Call / Log / copy action row). Placed between the project row and the meta row. Same amber palette as the dashboard chip for consistency.

Reads from either field:

```js
lead.budget       // numeric (e.g. 300000)
lead.budget_range // string label (e.g. "3-5 लाख", "Above 10L")
```

Whichever is present, that's what renders. Both null → no chip.

## Why both field names

There's already a partial budget renderer in this same file at line 474 using `lead.budget_range`, but it's on a **different card variant** that isn't currently rendered in production. The card variant that IS shown (line 572+) had no budget. This PR adds the chip there, supporting either field name to cover whatever the data actually uses.

## Files

| File | Change |
|---|---|
| `src/crm/pages/MyLeads.jsx` | +7 lines, 0 deletes |

## Risk

Zero — pure additive UI in one card variant. Mirrors PR #103's approach exactly.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_