### PR TITLE
🚨 hotfix: bump useMyLeads cache key — "Something went wrong" for cached sessions

### DIFF
--- a/src/crm/hooks/useMyLeads.js
+++ b/src/crm/hooks/useMyLeads.js
@@ -103,8 +103,13 @@ const LEAD_COLUMNS = [
 // HOOK
 // ═══════════════════════════════════════════════════════════════════════════════
 export const useMyLeads = (userId) => {
-  const leadsKey = userId ? `my_leads_${userId}` : null;
-  const callsKey = userId ? `my_calls_${userId}` : null;
+  // Cache version suffix. Bump this whenever the cached lead/call object
+  // shape changes — old caches become unreachable so existing-session
+  // users get fresh data instead of a renderer crash when an old field
+  // is missing/restructured.
+  //   v2: post-restore from PR #98, slim-column normalize step in PR #105
+  const leadsKey = userId ? `my_leads_v2_${userId}` : null;
+  const callsKey = userId ? `my_calls_v2_${userId}` : null;
 
   const [leads, setLeads]               = useState(() => (userId ? readCache(`my_leads_${userId}`, LEADS_TTL) || [] : []));
   const [leadsLoading, setLeadsLoading] = useState(() => !(userId && readCache(`my_leads_${userId}`, LEADS_TTL)));

--- a/src/crm/hooks/useMyLeads.js
+++ b/src/crm/hooks/useMyLeads.js
@@ -111,9 +111,9 @@ export const useMyLeads = (userId) => {
   const leadsKey = userId ? `my_leads_v2_${userId}` : null;
   const callsKey = userId ? `my_calls_v2_${userId}` : null;
 
-  const [leads, setLeads]               = useState(() => (userId ? readCache(`my_leads_${userId}`, LEADS_TTL) || [] : []));
-  const [leadsLoading, setLeadsLoading] = useState(() => !(userId && readCache(`my_leads_${userId}`, LEADS_TTL)));
-  const [calls, setCalls]               = useState(() => (userId ? readCache(`my_calls_${userId}`, CALLS_TTL) || [] : []));
+  const [leads, setLeads]               = useState(() => (leadsKey ? readCache(leadsKey, LEADS_TTL) || [] : []));
+  const [leadsLoading, setLeadsLoading] = useState(() => !(leadsKey && readCache(leadsKey, LEADS_TTL)));
+  const [calls, setCalls]               = useState(() => (callsKey ? readCache(callsKey, CALLS_TTL) || [] : []));
 
   const leadsReqId  = useRef(0);
   const callsReqId  = useRef(0);


### PR DESCRIPTION
## 🚨 Production hotfix — "Something went wrong" for existing sessions

**Symptom**: CRM crashes with the "Something went wrong" ErrorBoundary for users with an existing logged-in session. **Works fine in fresh Incognito tab.**

That's the textbook signature of a stale-cache issue:
- Incognito has no `localStorage` → fetches fresh data → renders normally
- Existing sessions have OLD cached lead objects → the new bundle's renderer blows up before the background refetch can replace them

## Where the stale cache lives

`useMyLeads.js` line 106:
```js
const leadsKey = userId ? `my_leads_${userId}` : null;
```

This writes the per-user lead list to `localStorage` and reads it back on every mount — BEFORE `fetchLeads(true)` runs in the background. If the cached shape doesn't match the current normalizer, renderers crash on the cache, never reaching the refetch.

## Fix

Bump the key to `my_leads_v2_<userId>` (and `my_calls_v2_<userId>`). Existing caches become unreachable → `useMyLeads` sees "no cache" → does a fresh foreground fetch → normalized objects match the renderer → no crash.

```diff
- const leadsKey = userId ? `my_leads_${userId}` : null;
- const callsKey = userId ? `my_calls_${userId}` : null;
+ const leadsKey = userId ? `my_leads_v2_${userId}` : null;
+ const callsKey = userId ? `my_calls_v2_${userId}` : null;
```

## User impact

- **First load after deploy**: 1× extra Supabase round-trip per user (cache is "missing"). Slight delay, then normal.
- **All subsequent loads**: same as before.
- **No schema or behavior changes** — just a localStorage key bump.

## Going forward

Bump the suffix again any time the cached lead/call object shape changes meaningfully (added/removed/renamed fields the renderer accesses). I'll add this to the playbook.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_