### PR TITLE
🚨 hotfix: CRM loading slow (gate useCRMData) + Attendance broken (use authed supabase)

### DIFF
--- a/src/crm/components/CRMLayout.jsx
+++ b/src/crm/components/CRMLayout.jsx
@@ -18,14 +18,18 @@ const ADMIN_ROLES = [ROLES.SUPER_ADMIN, ROLES.SUB_ADMIN, ROLES.HR_MANAGER];
 
 const CRMLayout = ({ children }) => {
   const { user } = useAuth();
-  const { leads, employees } = useCRMData();
+  // PERF: only super_admin actually needs { leads, employees } here (for the
+  // daily-digest check). Pass enabled:false for everyone else so non-admin
+  // page-loads don't fetch the full 4948-row leads table 5× paginated.
+  const needsCRMData = user?.role === ROLES.SUPER_ADMIN;
+  const { leads, employees } = useCRMData({ enabled: needsCRMData });
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
-    if (user?.role === ROLES.SUPER_ADMIN) {
+    if (needsCRMData) {
       checkDailyDigest(leads, employees);
     }
-  }, [user, leads, employees]);
+  }, [needsCRMData, leads, employees]);
 
   if (!user) {
     return (

--- a/src/crm/hooks/useCRMData.js
+++ b/src/crm/hooks/useCRMData.js
@@ -199,7 +199,7 @@ export const useCRMData = ({ enabled = true } = {}) => {
       supabaseAdmin.removeChannel(bookingsChannel);
       document.removeEventListener('visibilitychange', handleVisibility);
     };
-  }, []);
+  }, [enabled]);
 
   // Compute workLogs from real Supabase data
   useEffect(() => {

--- a/src/crm/hooks/useCRMData.js
+++ b/src/crm/hooks/useCRMData.js
@@ -60,13 +60,19 @@ const STORAGE_KEYS = {
   AUDIT_LOGS:      'crm_audit_logs',
 };
 
-export const useCRMData = () => {
+// Pass `{ enabled: false }` to skip the heavy initial fetches and realtime
+// subscriptions. Use this for non-admin users where the consumer only needs
+// mutator functions (addLead, updateLead, etc.) but not the cached list of
+// 4948 leads — calling this hook unconditionally inside CRMLayout was
+// causing every employee page-load to fetch the full leads table 5×
+// paginated, which is what made the CRM feel slow.
+export const useCRMData = ({ enabled = true } = {}) => {
   const [leads, setLeads]                         = useState([]);
-  const [leadsLoading, setLeadsLoading]           = useState(true);
+  const [leadsLoading, setLeadsLoading]           = useState(enabled);
   const [employees, setEmployees]                 = useState([]);
-  const [employeesLoading, setEmployeesLoading]   = useState(true);
+  const [employeesLoading, setEmployeesLoading]   = useState(enabled);
   const [calls, setCalls]                         = useState([]);
-  const [callsLoading, setCallsLoading]           = useState(true);
+  const [callsLoading, setCallsLoading]           = useState(enabled);
   const [siteVisits, setSiteVisits]               = useState([]);
   const [siteVisitsLoading, setSiteVisitsLoading] = useState(true);
   const [bookings, setBookings]                   = useState([]);
@@ -109,14 +115,24 @@ export const useCRMData = () => {
     setAuditLogs(get(STORAGE_KEYS.AUDIT_LOGS, []));
   }, []);
 
-  // Initial fetch
+  // Initial fetch — only when enabled. Non-admin callers (e.g. CRMLayout
+  // for an employee role) pass enabled:false and get the mutator-only API
+  // without the 5-round-trip paginated leads load.
   useEffect(() => {
+    if (!enabled) {
+      setLeadsLoading(false);
+      setEmployeesLoading(false);
+      setCallsLoading(false);
+      setSiteVisitsLoading(false);
+      setBookingsLoading(false);
+      return;
+    }
     fetchLeads();
     fetchEmployees();
     fetchCalls();
     fetchSiteVisits();
     fetchBookings();
-  }, []);
+  }, [enabled]);
 
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   // ✅ SUPABASE REALTIME SUBSCRIPTIONS
@@ -130,6 +146,9 @@ export const useCRMData = () => {
   // Unique names per mount eliminate that collision entirely.
   const channelSuffix = useId().replace(/:/g, '');
   useEffect(() => {
+    // Skip realtime subscriptions when disabled — non-admin callers don't
+    // need them and they're expensive (4 channels × postgres_changes).
+    if (!enabled) return;
     // Coalesce realtime-triggered refetches per-table — a burst of writes
     // shouldn't trigger a flurry of independent full-table reloads.
     const debouncedFetchLeads      = makeDebounced(fetchLeads,      REALTIME_REFETCH_DEBOUNCE_MS);

--- a/src/crm/pages/Attendance.jsx
+++ b/src/crm/pages/Attendance.jsx
@@ -2,7 +2,11 @@
 // Employee attendance page — GPS-verified punch in/out with selfie capture
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '@/context/AuthContext';
-import { supabaseAdmin } from '@/lib/supabase';
+// Use the regular (authenticated) supabase client — NOT supabase.
+// The attendance RLS policies allow `authenticated` role only; supabase
+// is created with persistSession:false so its requests go as anon, which RLS
+// blocks. Net effect was: INSERT/UPDATE on attendance silently failed.
+import { supabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast';
 import { Button } from '@/components/ui/button';
 import {
@@ -120,7 +124,7 @@ const Attendance = () => {
     if (!userId) return;
     setLoading(true);
     try {
-      const { data: today } = await supabaseAdmin
+      const { data: today } = await supabase
         .from('attendance')
         .select('*')
         .eq('employee_id', userId)
@@ -128,7 +132,7 @@ const Attendance = () => {
         .maybeSingle();
       setTodayRecord(today || null);
 
-      const { data: hist } = await supabaseAdmin
+      const { data: hist } = await supabase
         .from('attendance')
         .select('*')
         .eq('employee_id', userId)
@@ -180,7 +184,7 @@ const Attendance = () => {
     try {
       if (!todayRecord) {
         // First punch = clock IN
-        const { error } = await supabaseAdmin.from('attendance').insert({
+        const { error } = await supabase.from('attendance').insert({
           employee_id:       userId,
           employee_name:     user?.name || user?.username || 'Employee',
           date:              todayStr,
@@ -197,7 +201,7 @@ const Attendance = () => {
         // Clock OUT
         const mins = differenceInMinutes(now, parseISO(todayRecord.punch_in));
         const status = mins >= 480 ? 'present' : mins >= 240 ? 'half_day' : 'present';
-        const { error } = await supabaseAdmin.from('attendance').update({
+        const { error } = await supabase.from('attendance').update({
           punch_out:          nowISO,
           punch_out_lat:      gpsData.lat,
           punch_out_lng:      gpsData.lng,


### PR DESCRIPTION
## 🚨 Two production hotfixes in one PR

Both root-caused from real complaints in the last hour.

### 1. "CRM loading slow" — every employee

**Root cause:** `CRMLayout.jsx` was calling `useCRMData()` unconditionally for every CRM user. `useCRMData` paginates the **full** `leads` table (1000 × 5 round-trips = ~5000 rows), but employees only need their OWN leads via `useMyLeads`. The 4948-row admin payload + 4 realtime subscriptions was loading for every employee on every page-load.

**Fix:**
- `useCRMData` now takes `{ enabled }` (defaults `true`, backward-compatible with the 10+ other admin callers)
- When `enabled:false`: skips `fetchLeads / fetchEmployees / fetchCalls / fetchSiteVisits / fetchBookings` + all 4 realtime channels
- `CRMLayout` passes `enabled: user?.role === SUPER_ADMIN` (the only role that actually uses `{ leads, employees }` here — for the dailyDigest scheduler)

Employee page-load drops from "fetch ~5k rows + 4 realtime channels" to "no extra work at the layout level". Their actual data still comes from `useMyLeads` (slim, scoped, already optimized).

### 2. "Attendance not working" — punch-in silently failing

**Root cause:** `src/crm/pages/Attendance.jsx` used `supabaseAdmin` for every read + INSERT/UPDATE. But `supabaseAdmin` is configured with `persistSession:false` (correct for an admin-bypass client), which means it carries only the **anon** key — never the user's logged-in JWT.

The attendance RLS policies (`attendance_authenticated_insert/update/select/delete`) only grant `authenticated` role. So every employee punch was being silently denied by RLS — same trap that broke login in PR #98 era.

**Fix:** switch `supabaseAdmin` → `supabase` (the persisted-session client). After login, this client carries the user's JWT → RLS sees `authenticated` → grants the operation.

## Files

| File | Change |
|---|---|
| `src/crm/hooks/useCRMData.js` | Add `{ enabled }` option, gate initial fetch + realtime |
| `src/crm/components/CRMLayout.jsx` | Pass `enabled: needsCRMData` |
| `src/crm/pages/Attendance.jsx` | `supabaseAdmin` → `supabase` (4 call sites) |

3 files, +41/-14.

## Risk

- **useCRMData**: option is additive with safe default; existing callers unchanged.
- **CRMLayout**: only super_admin gets data — same behavior as before (the existing `if (user?.role === SUPER_ADMIN)` guard around `checkDailyDigest` already meant non-admin data was wasted).
- **Attendance**: now goes through RLS as authenticated user. Worst case: a policy you didn't realize existed denies a specific operation. RLS check shows insert/update/select/delete all allow authenticated, so should be transparent.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_