### PR TITLE
feat(crm): freshly-assigned leads pin to top + "✨ NEW" badge (48h window)

### DIFF
--- a/src/crm/pages/EmployeeCRMHome.jsx
+++ b/src/crm/pages/EmployeeCRMHome.jsx
@@ -329,6 +329,25 @@ const EmployeeCRMHome = () => {
       const callScore  = callStatus === 'never_called' ? 100 : callStatus === 'needs_retry' ? 80 : callStatus === 'recently_unanswered' ? 40 : 10;
       const fuScore    = followUpPriority <= 2 ? 50 : followUpPriority === 3 ? 30 : 0;
       const assignedAt = lead.assignmentDate || lead.assignment_date || lead.assignedAt || lead.assigned_at || lead.createdAt || lead.created_at || null;
+      // Per ops feedback: when admin reassigns a lead to an employee it
+      // should be treated as a new lead — surface to top of the list so
+      // the employee calls it first. The admin reassign flow already
+      // updates `assigned_at` to NOW, so any lead with assigned_at
+      // within the last 48h gets a big freshness bonus regardless of
+      // its carried-over status / follow-up date / interest level.
+      // Also flags _isFreshAssignment so the lead card can show a NEW
+      // badge.
+      let freshBonus = 0;
+      let isFreshAssignment = false;
+      if (assignedAt) {
+        try {
+          const hoursSinceAssigned = differenceInHours(now, new Date(assignedAt));
+          if (hoursSinceAssigned >= 0 && hoursSinceAssigned <= 48) {
+            isFreshAssignment = true;
+            freshBonus = 200; // larger than max baseline score so fresh leads pin to top
+          }
+        } catch { /* ignore */ }
+      }
       return {
         ...lead,
         _callStatus: callStatus,
@@ -339,7 +358,8 @@ const EmployeeCRMHome = () => {
         _daysUntilFollowUp: daysUntilFollowUp,
         _interest: interest,
         _normalizedStatus: status,
-        _score: callScore + fuScore + tempScore,
+        _score: callScore + fuScore + tempScore + freshBonus,
+        _isFreshAssignment: isFreshAssignment,
         _assignedAt: assignedAt,
       };
     });
@@ -993,6 +1013,11 @@ const LeadCallCard = React.memo(({ lead, rank, onAction, onNavigate, compact, on
             {getInterestDot()}
           </div>
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
+            {lead._isFreshAssignment && (
+              <span className="text-[9px] font-extrabold text-white bg-emerald-500 px-1.5 py-0.5 rounded animate-pulse">
+                ✨ NEW
+              </span>
+            )}
             {lead.project && <span className="text-[10px] text-gray-400 truncate max-w-[100px]">{lead.project}</span>}
             {lead.budget && (
               <span className="text-[10px] font-bold text-amber-800 bg-amber-50 px-1.5 py-0.5 rounded">


### PR DESCRIPTION
## Why

Ops feedback: *"When admin reassigns any lead to employees it should be treated as new lead and come at top so employee can call them first."*

You showed a screenshot of Lead Management → Assigned tab → 487 reassigned leads to `chetna fg`, dated **19 May 2026 04:03 PM**. Those should be at the TOP of chetna's call list with a clear visual marker, regardless of their previous status.

## What's already in place (didn't need changing)

`ReassignLeads.jsx` already updates these fields on every reassign:
```js
assigned_at:   new Date().toISOString(),  // ← the "newness" timestamp
reassigned_at: new Date().toISOString(),
prev_assigned_to, prev_assigned_to_name, prev_assigned_at, reassigned_by
```

The data was there. The employee dashboard just wasn't using it for sort or visual.

## What this PR adds

Two changes in `EmployeeCRMHome.jsx`:

### 1. Scoring boost — pins fresh leads to the top

```js
if (hoursSinceAssigned >= 0 && hoursSinceAssigned <= 48) {
  isFreshAssignment = true;
  freshBonus = 200;  // larger than max baseline (180) → always on top
}
_score: callScore + fuScore + tempScore + freshBonus
```

Score model (recap):
- never_called: 100, needs_retry: 80, recently_unanswered: 40, connected: 10
- overdue/today follow-up: 50
- Hot: 30, Warm: 20, Cold: 10
- **NEW: fresh assignment (≤48h): 200**

| Lead | Before | After |
|---|---|---|
| Reassigned NotInterested Cold | 110 | **310** ← top |
| Fresh Hot Open never-called | 140 | **340** ← top |
| Stale Open never-called Cold overdue follow-up | 160 | 160 |

Both first-time AND reassigned leads benefit — both are "new to me" from the employee's perspective.

### 2. Visual — pulsing "✨ NEW" badge

Front of the lead-card meta row (before project, budget, status):

```jsx
{lead._isFreshAssignment && (
  <span className="text-[9px] font-extrabold text-white bg-emerald-500 px-1.5 py-0.5 rounded animate-pulse">
    ✨ NEW
  </span>
)}
```

Drops off automatically after 48h.

## Tunable

`hoursSinceAssigned <= 48` — 48h covers a Friday reassign + Monday morning call. Adjust if ops wants a different window.

## Risk

Zero. Purely client-side scoring + 1 JSX badge. No backend / schema / RLS changes. Reassign flow itself untouched.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_