### PR TITLE
feat(android): bundle CRM in APK (fixes slow load) + publish public download link

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -87,10 +87,41 @@ jobs:
           echo "Found APK at: $APK_PATH"
           ls -lah "$APK_PATH"
 
-      - name: Upload APK artifact
+      - name: Upload APK artifact (login-only)
         uses: actions/upload-artifact@v4
         with:
           name: fanbe-crm-debug-apk
           path: ${{ steps.locate.outputs.apk_path }}
           retention-days: 30
           if-no-files-found: error
+
+      # Public, shareable download URL via a rolling GitHub Release.
+      # Permanent path:
+      #   https://github.com/<owner>/<repo>/releases/download/latest-android/app-debug.apk
+      # The release is overwritten on every push to main, so the URL is
+      # stable but always points at the newest build. Only runs on main
+      # pushes (skipped on PRs).
+      - name: Stage APK with stable filename for release upload
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p release-staging
+          cp "${{ steps.locate.outputs.apk_path }}" release-staging/app-debug.apk
+
+      - name: Publish to rolling 'latest-android' release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest-android
+          name: Latest Android APK (auto-built)
+          body: |
+            Auto-built APK from commit ${{ github.sha }}.
+
+            Direct download (always points at the newest build):
+            https://github.com/${{ github.repository }}/releases/download/latest-android/app-debug.apk
+
+            Build timestamp: ${{ github.event.head_commit.timestamp }}
+          files: release-staging/app-debug.apk
+          prerelease: true
+          make_latest: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -2,11 +2,6 @@
   "appId": "com.fanbegroup.crm",
   "appName": "Fanbe CRM",
   "webDir": "dist",
-  "server": {
-    "url": "https://fanbegroup.com/crm/login",
-    "cleartext": false,
-    "androidScheme": "https"
-  },
   "android": {
     "allowMixedContent": false,
     "backgroundColor": "#0F3A5F",


### PR DESCRIPTION
## What

Two fixes for the Android app, both prompted by your feedback today:

### 1. App "loads on every click — not fast like native"

**Cause:** `capacitor.config.json` had `server.url` pointing at `https://fanbegroup.com/crm/login`. That makes the APK a thin WebView wrapper opening a remote URL — every page navigation re-hydrates the bundle + assets over the network. Splash → blank → spinner → content is the exact symptom you screenshotted.

**Fix:** remove the `server` block. Capacitor now bundles `dist/` inside the APK (`android/app/src/main/assets/public/`). Shell loads from local disk on every launch + navigation — instant. **Only Supabase data calls hit the network now.**

**Trade-off:** each CRM UI release needs a new APK. The GitHub Action auto-builds on every main push, so it's free.

### 2. "Direct downloadable link of APK"

**Cause:** Actions artifacts are gated behind GitHub login. Can't share with telecallers as a plain link.

**Fix:** workflow now also publishes the APK to a rolling **`latest-android`** GitHub Release on every main push.

**After this lands, the permanent shareable URL is:**

```
https://github.com/fadoomotivation-pixel/fanbe-hostinger/releases/download/latest-android/app-debug.apk
```

Anyone on the internet can download — no GitHub account needed. Subsequent main pushes overwrite the asset; the URL stays stable.

## Install flow for telecallers

1. Open the URL above on their phone's browser → APK downloads.
2. Tap the downloaded file → Android prompts "Install unknown apps" → enable for current browser → Install.
3. Launch "Fanbe CRM" from the home screen → login screen appears instantly.

## Files

| File | Change |
|---|---|
| `capacitor.config.json` | Remove `server` block → APK bundles `dist/` |
| `.github/workflows/android-apk.yml` | Add `softprops/action-gh-release@v2` step that publishes to the rolling `latest-android` release on main pushes |

## Risk

- APK gets bigger (probably ~3-4 MB → ~7-10 MB). Acceptable for a sales CRM.
- The release-publish step only runs on `main` pushes (skipped on PRs) so it can't fire prematurely.
- Uses built-in `GITHUB_TOKEN` — no extra secrets needed.

## What you'll see after merge

1. Action runs (~5-8 min).
2. New `latest-android` release appears on the repo's Releases page with `app-debug.apk` as an asset.
3. The download URL works publicly.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_