### PR TITLE
🚨 hotfix(ci): grant contents:write to APK workflow so public release publishes

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -35,6 +35,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # Default GITHUB_TOKEN scope is read-only. Need `contents: write` so the
+    # softprops/action-gh-release step below can create/update the rolling
+    # `latest-android` release. Without this, that step fails with HTTP 403
+    # "Resource not accessible by integration" — APK still builds + uploads
+    # as a (login-only) artifact, but the public download URL never appears.
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## 🚨 Workflow hotfix — APK release publish failing 403

PR #113's APK action builds correctly (you can see the **4.49 MB `fanbe-crm-debug-apk`** artifact attached to the latest run), but the **"Publish to rolling latest-android release"** step fails with:

```
GitHub release failed with status: 403
{"message":"Resource not accessible by integration"}
```

So the public download URL never appears.

## Cause

GitHub's default `GITHUB_TOKEN` for workflow runs is read-only on this repo. `softprops/action-gh-release@v2` needs write access to repo contents to create/update releases.

## Fix

One-block addition to `.github/workflows/android-apk.yml`:

```yaml
jobs:
  build:
    runs-on: ubuntu-latest
    timeout-minutes: 25
    permissions:
      contents: write
```

Scoped to this single workflow — the broader repo default stays read-only for everything else.

## After merge

The next run on main will succeed at the publish step. The permanent URL becomes live:

**https://github.com/fadoomotivation-pixel/fanbe-hostinger/releases/download/latest-android/app-debug.apk**

Subsequent main pushes overwrite the asset; URL stays stable.

## Right now (before this merges)

You can still get the APK manually:
1. Repo → **Actions** tab → latest "Build Android APK" run
2. Scroll to **Artifacts** → download `fanbe-crm-debug-apk.zip`
3. Inside: `app-debug.apk` (4.49 MB)

Just requires GitHub login. After this hotfix merges, no login needed.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_