### PR TITLE
perf: instant lead-detail from ALL tap sites (FollowUp sub-sections + Search + MobileLeadList)

### DIFF
--- a/src/crm/pages/EmployeeCRMHome.jsx
+++ b/src/crm/pages/EmployeeCRMHome.jsx
@@ -197,7 +197,7 @@ const GlobalSearchOverlay = ({ leads, onClose, onNavigate }) => {
                 return (
                   <div
                     key={lead.id}
-                    onClick={() => { onNavigate(lead.id); onClose(); }}
+                    onClick={() => { onNavigate(lead); onClose(); }}
                     style={{
                       display: 'flex', alignItems: 'center', gap: 12,
                       padding: '11px 16px', cursor: 'pointer',
@@ -702,32 +702,32 @@ const EmployeeCRMHome = () => {
             {followUpCounts.overdue > 0 && (
               <FollowUpSection title="Overdue" icon={<AlertCircle size={14} className="text-red-600" />}
                 leads={followUpLeads.overdue} color="border-red-200 bg-red-50" onAction={openAction}
-                onNavigate={(id) => navigate(`/crm/sales/lead/${id}`)} />
+                onNavigate={(lead) => navigate(`/crm/sales/lead/${lead.id}`, { state: { lead } })} />
             )}
             {followUpCounts.yesterday > 0 && (
               <FollowUpSection title="Yesterday" icon={<Clock size={14} className="text-orange-600" />}
                 leads={followUpLeads.yesterday} color="border-orange-200 bg-orange-50" onAction={openAction}
-                onNavigate={(id) => navigate(`/crm/sales/lead/${id}`)} />
+                onNavigate={(lead) => navigate(`/crm/sales/lead/${lead.id}`, { state: { lead } })} />
             )}
             {followUpCounts.today > 0 && (
               <FollowUpSection title="Today" icon={<Clock size={14} className="text-amber-600" />}
                 leads={followUpLeads.today} color="border-amber-200 bg-amber-50" onAction={openAction}
-                onNavigate={(id) => navigate(`/crm/sales/lead/${id}`)} />
+                onNavigate={(lead) => navigate(`/crm/sales/lead/${lead.id}`, { state: { lead } })} />
             )}
             {followUpCounts.tomorrow > 0 && (
               <FollowUpSection title="Tomorrow" icon={<Calendar size={14} className="text-blue-600" />}
                 leads={followUpLeads.tomorrow} color="border-blue-200 bg-blue-50" onAction={openAction}
-                onNavigate={(id) => navigate(`/crm/sales/lead/${id}`)} />
+                onNavigate={(lead) => navigate(`/crm/sales/lead/${lead.id}`, { state: { lead } })} />
             )}
             {followUpCounts.thisWeek > 0 && (
               <FollowUpSection title="This Week" icon={<Calendar size={14} className="text-indigo-600" />}
                 leads={followUpLeads.thisWeek} color="border-indigo-200 bg-indigo-50" onAction={openAction}
-                onNavigate={(id) => navigate(`/crm/sales/lead/${id}`)} />
+                onNavigate={(lead) => navigate(`/crm/sales/lead/${lead.id}`, { state: { lead } })} />
             )}
             {followUpLeads.noDate.length > 0 && (
               <FollowUpSection title="No Date Set" icon={<Calendar size={14} className="text-gray-400" />}
                 leads={followUpLeads.noDate} color="border-gray-200 bg-gray-50" onAction={openAction}
-                onNavigate={(id) => navigate(`/crm/sales/lead/${id}`)} />
+                onNavigate={(lead) => navigate(`/crm/sales/lead/${lead.id}`, { state: { lead } })} />
             )}
             {followUpCounts.total === 0 && followUpLeads.noDate.length === 0 && (
               <EmptyState message="No follow-ups scheduled. You're all caught up!" icon={Check} />
@@ -820,7 +820,7 @@ const EmployeeCRMHome = () => {
         <GlobalSearchOverlay
           leads={myLeads}
           onClose={() => setGlobalSearchOpen(false)}
-          onNavigate={(id) => navigate(`/crm/sales/lead/${id}`)}
+          onNavigate={(lead) => navigate(`/crm/sales/lead/${lead.id}`, { state: { lead } })}
         />
       )}
 
@@ -1099,7 +1099,7 @@ const FollowUpSection = React.memo(({ title, icon, leads, color, onAction, onNav
         const latestNote = getLatestNote(lead.notes);
         return (
           <div key={lead.id} className="flex items-center gap-2 px-3 py-2.5">
-            <div className="flex-1 min-w-0" onClick={() => onNavigate(lead.id)}>
+            <div className="flex-1 min-w-0" onClick={() => onNavigate(lead)}>
               <p className="font-semibold text-sm text-gray-800 truncate">{lead.name}</p>
               <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
                 {lead.project && <span className="text-[10px] text-gray-400">{lead.project}</span>}

--- a/src/crm/pages/MobileLeadList.jsx
+++ b/src/crm/pages/MobileLeadList.jsx
@@ -414,7 +414,7 @@ const MobileLeadList = () => {
                     isToday ? 'border-yellow-200 border-l-4 border-l-yellow-500' :
                     'border-gray-100 hover:border-gray-200 hover:shadow-md'
                   }`}
-                  onClick={() => navigate(`/crm/lead/${lead.id}`)}
+                  onClick={() => navigate(`/crm/lead/${lead.id}`, { state: { lead } })}
                 >
                   <div className="px-4 pt-3.5 pb-1.5 flex items-start justify-between">
                     <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Why

After PR #116, you said: "homepage error is gone but still load slow" for lead detail.

PR #116 seeded only the 3 lead-tap call sites where `lead` was already in scope at the tap. **7 more sites still passed only the id** — those keep going through the single-row Supabase fetch on every tap, hence the 2-second wait persists.

## Fix

Change the `onNavigate` signature inside the sub-components from `onNavigate(lead.id)` to `onNavigate(lead)`, then update each call site to pass `{ state: { lead } }`:

```diff
- onNavigate={(id)   => navigate(`/crm/sales/lead/${id}`)}
+ onNavigate={(lead) => navigate(`/crm/sales/lead/${lead.id}`, { state: { lead } })}
```

## Sites covered

| Page / Component | Tap sites |
|---|---|
| EmployeeCRMHome — Follow-Up tab (Overdue, Yesterday, Today, Tomorrow, This Week, No Date Set) | 6 |
| EmployeeCRMHome — GlobalSearchOverlay | 1 |
| MobileLeadList | 1 |

`MobileLeadDetails` already accepts `location.state.lead` as initial seed (from PR #116) — no changes there.

## Effective lead-tap latency

| | Before (2-step path) | After (all sites) |
|---|---|---|
| Tap from Call Now / All tabs | instant ✓ (already fixed in #116) | instant ✓ |
| Tap from Follow-Up sub-sections | ~2s (blocking) | **instant** ✓ |
| Tap from Global Search | ~2s | **instant** ✓ |
| Tap from MobileLeadList | ~2s | **instant** ✓ |

Background single-row Supabase fetch still runs to refresh with latest server-side data; the user just doesn't see a blocking spinner.

## Risk

Zero. Signature change is contained inside `FollowUpSection` + `GlobalSearchOverlay`, both defined locally in `EmployeeCRMHome.jsx`. No other consumers.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_