### PR TITLE
perf: debounce realtime refetches in useMyLeads — fixes "page reloads a lot" telecaller complaint

### DIFF
--- a/src/crm/hooks/useMyLeads.js
+++ b/src/crm/hooks/useMyLeads.js
@@ -186,13 +186,27 @@ export const useMyLeads = (userId) => {
   }, [userId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ─── Realtime subscription ─────────────────────────────────────────────────
+  // Debounce the realtime callback so a burst of admin writes (e.g. bulk
+  // reassign 50 leads to this employee) collapses into ONE refetch instead
+  // of 50 back-to-back full-table reloads. Telecallers reported the list
+  // "reloading a lot" — each in-flight refetch causes a setLeads → render
+  // that visibly disrupts the UI mid-call. 800ms trailing edge means the
+  // employee still sees fresh data within a second, but uncoordinated
+  // rapid writes get batched. Same pattern useCRMData uses (PR #105).
+  const REALTIME_DEBOUNCE_MS = 800;
   useEffect(() => {
     if (!userId) return;
+
+    let debounceTimer = null;
+    const scheduleRefetch = () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => { debounceTimer = null; fetchLeads(true); }, REALTIME_DEBOUNCE_MS);
+    };
 
     const channel = supabaseAdmin
       .channel(`my_leads_rt_${userId}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'leads', filter: `assigned_to=eq.${userId}` },
-        () => fetchLeads(true))
+        scheduleRefetch)
       .subscribe();
 
     const handleVisibility = () => {
@@ -200,13 +214,14 @@ export const useMyLeads = (userId) => {
         tabWasHidden.current = true;
       } else if (document.visibilityState === 'visible' && tabWasHidden.current) {
         tabWasHidden.current = false;
-        fetchLeads(true);
+        scheduleRefetch();
         fetchCalls(true);
       }
     };
     document.addEventListener('visibilitychange', handleVisibility);
 
     return () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
       supabaseAdmin.removeChannel(channel);
       document.removeEventListener('visibilitychange', handleVisibility);
     };


### PR DESCRIPTION
## Why

Telecaller feedback today:

> *"Pages reload a lot, impact on their productivity. Want pages to work smooth."*

## Root cause

`useMyLeads` subscribes to Supabase Realtime `postgres_changes` on the `leads` table filtered to `assigned_to=eq.<employee_id>`. **Every event fires `fetchLeads(true)` immediately** — no batching, no debouncing.

A bulk admin action (e.g. reassign 50 leads to one employee) becomes 50 back-to-back full-table refetches × ~600 rows each. `setLeads` triggers a render on every one. Mid-call, the telecaller sees their list flicker / re-order / "reload" repeatedly.

## Fix

800ms trailing-edge debounce around the realtime callback. Same pattern PR #105 already uses on the admin side in `useCRMData`.

```diff
- .on('postgres_changes', { ... }, () => fetchLeads(true))
+ const scheduleRefetch = () => {
+   if (debounceTimer) clearTimeout(debounceTimer);
+   debounceTimer = setTimeout(() => { ... fetchLeads(true); }, 800);
+ };
+ .on('postgres_changes', { ... }, scheduleRefetch)
```

| Scenario | Before | After |
|---|---|---|
| Admin reassigns 50 leads | 50 refetches in a few sec | **1 refetch**, 800ms after the last write |
| Single status change | 1 refetch immediately | 1 refetch 800ms later (imperceptible) |
| Tab returns from hidden | 1 immediate refetch | Goes through the same debounce |
| User-initiated updateLead | Local optimistic update (unchanged) | Same — no debounce on user actions |

## Files

| File | Change |
|---|---|
| `src/crm/hooks/useMyLeads.js` | +17 / -2 lines |

## Risk

Low. 800ms is well under "feels stale" territory. The user-initiated paths (`updateLead`, `addCallLog`) bypass the debounce — those still update local state immediately for the one row that changed.

## Related — about "lead detail still slow"

You also mentioned individual lead click still loads slow. PR #117 fixed 7 additional tap sites that weren't seeded with `state`. That fix is in the JS bundle — Android WebView caches the OLD bundle aggressively. **Please uninstall + reinstall the Fanbe CRM** from the public URL once the next Android Action finishes. If still slow after a clean reinstall from a fresh APK, tell me the exact tap path and I'll diagnose.

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_