### PR TITLE
fix(crm): reassigned leads appear in 'New' tab on My Leads (48h freshness window)

### DIFF
--- a/src/crm/pages/MyLeads.jsx
+++ b/src/crm/pages/MyLeads.jsx
@@ -220,7 +220,26 @@ const MyLeads = () => {
     else if (tab==='today')     arr=arr.filter(l=>{ if(TERMINAL.includes(l.status))return false; const d=parseLocalDate(l.follow_up_date||l.followUpDate); return d&&isToday(d); });
     else if (tab==='tomorrow')  arr=arr.filter(l=>{ if(TERMINAL.includes(l.status))return false; const d=parseLocalDate(l.follow_up_date||l.followUpDate); return d&&isTomorrow(d); });
     else if (tab==='followup')  arr=arr.filter(l=>l.status==='FollowUp'||l.status==='CallBackLater');
-    else if (tab==='new')       { arr=arr.filter(l=>l.status==='New'||l.status==='Open'||!l.status); arr=[...arr].sort((a,b)=>new Date(b.assignedAt||b.createdAt||0)-new Date(a.assignedAt||a.createdAt||0)); }
+    else if (tab==='new')       {
+      // "New" tab includes genuinely new leads (status New/Open/empty) AND any
+      // lead freshly assigned to this telecaller within the last 48h —
+      // even if the lead's STATUS is carried over (NotInterested, FollowUp,
+      // etc.) from a previous owner via admin reassignment. Admin reassigns
+      // because they want this person to try again; the receiving telecaller
+      // shouldn't have to dig through the "All" tab to find their newly-
+      // handed leads. Matches the 48h freshBonus window from PR #109.
+      const FRESH_HOURS = 48;
+      const now = Date.now();
+      arr = arr.filter(l => {
+        if (l.status === 'New' || l.status === 'Open' || !l.status) return true;
+        if (TERMINAL.includes(l.status)) return false; // Booked / Lost don't belong even if reassigned
+        const t = new Date(l.assignedAt || l.assigned_at || 0).getTime();
+        if (!t) return false;
+        const hoursSinceAssigned = (now - t) / (1000 * 60 * 60);
+        return hoursSinceAssigned >= 0 && hoursSinceAssigned <= FRESH_HOURS;
+      });
+      arr = [...arr].sort((a,b) => new Date(b.assignedAt||b.createdAt||0) - new Date(a.assignedAt||a.createdAt||0));
+    }
     else if (tab==='booked')    arr=arr.filter(l=>l.status==='Booked');
     if (search.trim()) { const q=search.toLowerCase(); arr=arr.filter(l=>l.name?.toLowerCase().includes(q)||l.phone?.includes(q)||l.project?.toLowerCase().includes(q)); }
     if (dateFilter) arr=arr.filter(l=>{ const fu=l.follow_up_date||l.followUpDate; const cr=(l.createdAt||'').split('T')[0]; const as=(l.assignedAt||'').split('T')[0]; return fu===dateFilter||cr===dateFilter||as===dateFilter; });


### PR DESCRIPTION
## Why

> *"I reassign the leads it is not showing in new, it showing in all — it's confusing the telecaller."*

You showed the admin "Show Reassigned Only" view with 1020 leads reassigned from `ankita pal` to `Priyanka Fb`, carrying statuses like NotInterested / FollowUp / etc. On Priyanka's CRM, those land in the "All" tab but NOT in "New" — even though she's never called them.

## Cause

`MyLeads.jsx` line 223 filters the "New" tab strictly by status:

```js
arr.filter(l => l.status === 'New' || l.status === 'Open' || !l.status)
```

A reassigned lead inherits the previous owner's status, so it gets excluded from "New" even though it's fresh to the receiving telecaller.

## Fix

Also include leads whose `assigned_at` is within the last **48 hours** — matches the freshness window from PR #109 (the freshBonus scoring + "✨ NEW" badge on the dashboard).

```js
// Now "New" includes:
//   • Genuinely-new leads (status New/Open/empty), OR
//   • Freshly-assigned leads (≤48h ago) regardless of carried status
// Except Booked/Lost (terminal — no point re-pitching).
```

Sort order unchanged: most-recently-assigned first, so the latest batch lands at the top.

## What the user sees after this lands

Priyanka opens **My Leads → New** tab:
- All her brand-new leads (status Open/empty) — same as before
- **PLUS the 1020 reassigned-from-ankita leads** (within the 48h window)
- All sorted most-recent-first

No more "where did my reassigned leads go?" confusion.

## Risk

Low. Single tab filter on one page. Other tabs (Overdue / Today / Tomorrow / Follow Up / Booked / All) untouched. The 48h cutoff means stale reassignments naturally drop out — they remain visible in "All" but stop cluttering "New".

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_