### PR TITLE
fix(crm): drop lead from My Leads "New" tab once telecaller logs a call

### DIFF
--- a/src/crm/pages/MyLeads.jsx
+++ b/src/crm/pages/MyLeads.jsx
@@ -235,11 +235,18 @@ const MyLeads = () => {
       // fresh telecaller can retry — those must surface in New, not All.
       const NEW_TAB_TERMINAL = ['Lost','Booked'];
       arr = arr.filter(l => {
+        const assignedT = new Date(l.assignedAt || l.assigned_at || 0).getTime();
+        // Once the telecaller has logged a call AFTER (re)assignment, the lead
+        // has been contacted — drop it from "New" so it doesn't keep nagging
+        // them. It still appears in All / FollowUp / today etc. as appropriate.
+        if (assignedT && l._lastCall) {
+          const lastCallT = new Date(l._lastCall.timestamp || 0).getTime();
+          if (lastCallT >= assignedT) return false;
+        }
         if (l.status === 'New' || l.status === 'Open' || !l.status) return true;
         if (NEW_TAB_TERMINAL.includes(l.status)) return false;
-        const t = new Date(l.assignedAt || l.assigned_at || 0).getTime();
-        if (!t) return false;
-        const hoursSinceAssigned = (now - t) / (1000 * 60 * 60);
+        if (!assignedT) return false;
+        const hoursSinceAssigned = (now - assignedT) / (1000 * 60 * 60);
         return hoursSinceAssigned >= 0 && hoursSinceAssigned <= FRESH_HOURS;
       });
       arr = [...arr].sort((a,b) => new Date(b.assignedAt||b.createdAt||0) - new Date(a.assignedAt||a.createdAt||0));


### PR DESCRIPTION
## Summary

Telecallers were complaining that leads stayed in the **New** tab even after they called and logged the outcome. The previous filter only checked status + `assignedAt`, so a fresh lead with `last_activity` bumped (or status changed) still matched for the full 48h window.

### Change

In the New-tab filter, drop a lead as soon as a call has been logged at or after `assignedAt`:

```js
if (assignedT && l._lastCall) {
  const lastCallT = new Date(l._lastCall.timestamp || 0).getTime();
  if (lastCallT >= assignedT) return false;
}
```

`_lastCall` is already attached to each lead in `myLeads` (built from the per-employee `calls` table), so this is a free lookup — no schema change, no extra query.

### Why this is correct
- Once a telecaller has contacted a lead since the (re)assignment, it has been handled — it belongs in FollowUp / today / All based on the new status, not in New.
- The lead doesn't disappear: status updates from the call log will route it to the appropriate tab (FollowUp, today, NotInterested under All, etc.).
- Reassigned NotInterested leads still appear in New until the first call (the PR #120 behavior is preserved for uncalled leads).

## Test plan
- [ ] Open My Leads as a telecaller with several freshly-assigned NotInterested leads in New
- [ ] Log a call on one of them via Quick Log
- [ ] Confirm that lead disappears from New after the save / realtime refresh
- [ ] Confirm it shows under the appropriate tab based on its updated status (FollowUp / today / All)
- [ ] Confirm leads that haven't been called yet still appear in New

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_