### PR TITLE
fix(crm): show ALL freshly reassigned leads in "New" tab regardless of status

### DIFF
--- a/src/crm/pages/MyLeads.jsx
+++ b/src/crm/pages/MyLeads.jsx
@@ -240,20 +240,19 @@ const MyLeads = () => {
     else if (tab==='tomorrow')  arr=arr.filter(l=>{ if(TERMINAL.includes(l.status))return false; const d=parseLocalDate(l.follow_up_date||l.followUpDate); return d&&isTomorrow(d); });
     else if (tab==='followup')  arr=arr.filter(l=>l.status==='FollowUp'||l.status==='CallBackLater');
     else if (tab==='new')       {
-      // "New" tab includes:
-      //   1. Genuinely new leads (status New/Open/empty)
-      //   2. Reassigned NotInterested leads within 48h — admin reassigns
-      //      these so a fresh telecaller can retry; they wouldn't be
-      //      caught by any other tab.
-      // FollowUp / CallBackLater are EXCLUDED — they already have an
-      // explicit follow-up date and belong in the FollowUp tab. Showing
-      // them in New too was confusing telecallers who had to dig through
-      // the New tab looking for actually-new leads.
+      // "New" tab shows leads that are NEW TO THIS TELECALLER and not yet
+      // contacted by them. That means:
+      //   1. Always: status New/Open/empty
+      //   2. Reassigned within 48h AND not touched since assignment
+      //      (regardless of carried-over status like FollowUp/NotInterested/
+      //      Interested) — once the telecaller calls/saves, the touched-
+      //      since-assignment check drops it from New into its proper bucket.
+      // Booked/Lost are excluded — they're truly done.
       const FRESH_MS = 48 * 60 * 60 * 1000;
       const now = Date.now();
       arr = arr.filter(l => {
         const assignedT = l._assignedT;
-        // Touched-since-(re)assignment → drop. Two signals, either suffices.
+        // Touched-since-(re)assignment → drop. Either signal suffices.
         if (assignedT) {
           if (l._lastActT > assignedT) return false;
           if (l._lastCall) {
@@ -262,11 +261,10 @@ const MyLeads = () => {
           }
         }
         if (l.status === 'New' || l.status === 'Open' || !l.status) return true;
-        if (l.status === 'NotInterested' && assignedT) {
-          const msSinceAssigned = now - assignedT;
-          return msSinceAssigned >= 0 && msSinceAssigned <= FRESH_MS;
-        }
-        return false;
+        if (l.status === 'Lost' || l.status === 'Booked') return false;
+        if (!assignedT) return false;
+        const msSinceAssigned = now - assignedT;
+        return msSinceAssigned >= 0 && msSinceAssigned <= FRESH_MS;
       });
       arr = [...arr].sort((a,b) => b._assignedT - a._assignedT);
     }


### PR DESCRIPTION
## Summary

Screenshot from telecaller showed **820 leads assigned, 0 in the New tab**. PR #123 over-restricted New to only `New/Open/empty/NotInterested` — so any reassigned lead with a carried-over status (`FollowUp`, `Interested`, `CallBackLater`, etc.) became invisible despite being a fresh handoff.

### What "New" actually means

> "Leads I haven't touched yet since they became mine."

Status is mostly irrelevant — what matters is whether the **current** telecaller has worked on it since the (re)assignment. The touched-since-assignment check (`lastActivity > assignedAt` OR `_lastCall.timestamp >= assignedAt`) already does that job correctly, so the additional status filter from PR #123 was both redundant AND harmful.

### Change

Restore PR #120's intent: any non-Booked/Lost lead reassigned within 48h shows in New until first contact.

```js
if (l.status === 'New' || l.status === 'Open' || !l.status) return true;
if (l.status === 'Lost' || l.status === 'Booked') return false;
if (!assignedT) return false;
const msSinceAssigned = now - assignedT;
return msSinceAssigned >= 0 && msSinceAssigned <= FRESH_MS;
```

### Why the earlier "FollowUp in New" report doesn't break

That complaint is handled by the touched-since-assignment check, not the status filter:

- **Self-set FollowUp** (telecaller scheduled it themselves) → `updated_at > assigned_at` → dropped from New ✓
- **Reassigned FollowUp** (admin handed it over) → `updated_at === assigned_at` at reassignment time → stays in New until first contact ✓ (which is what telecaller actually wants — "I just got this, I should call them")

## Test plan
- [ ] Admin reassigns a batch with mixed statuses (FollowUp, Interested, NotInterested) → telecaller sees ALL of them in New
- [ ] Telecaller logs a call on one → it drops from New, surfaces in its proper tab
- [ ] Telecaller's own previously-scheduled FollowUp leads do NOT appear in New (touched-since-assignment drops them)
- [ ] Booked / Lost leads never appear in New
- [ ] After 48h, untouched reassigned leads age out of New into All

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_