### PR TITLE
fix(crm): tolerate updated_at trigger noise in "New" tab touched-check

### DIFF
--- a/src/crm/pages/MyLeads.jsx
+++ b/src/crm/pages/MyLeads.jsx
@@ -249,15 +249,22 @@ const MyLeads = () => {
       //      since-assignment check drops it from New into its proper bucket.
       // Booked/Lost are excluded — they're truly done.
       const FRESH_MS = 48 * 60 * 60 * 1000;
+      // Reassignment sets assigned_at and updated_at to the same `now`,
+      // but Postgres updated_at triggers commonly bump updated_at by a
+      // few microseconds AFTER the explicit value — making _lastActT
+      // very slightly > _assignedT even though the telecaller never
+      // touched the lead. Tolerate up to 60s of "trigger noise"
+      // before treating it as a real telecaller touch. A genuine
+      // call/save happens minutes later, far outside this window.
+      const TOUCH_TOLERANCE_MS = 60 * 1000;
       const now = Date.now();
       arr = arr.filter(l => {
         const assignedT = l._assignedT;
-        // Touched-since-(re)assignment → drop. Either signal suffices.
         if (assignedT) {
-          if (l._lastActT > assignedT) return false;
+          if (l._lastActT - assignedT > TOUCH_TOLERANCE_MS) return false;
           if (l._lastCall) {
             const lastCallT = new Date(l._lastCall.timestamp || 0).getTime();
-            if (lastCallT >= assignedT) return false;
+            if (lastCallT - assignedT > TOUCH_TOLERANCE_MS) return false;
           }
         }
         if (l.status === 'New' || l.status === 'Open' || !l.status) return true;


### PR DESCRIPTION
## Summary

Telecaller "chetna fg" had **820 leads assigned but the New tab still showed empty** despite PR #124 removing the status restriction.

### Root cause

The leads table has a Postgres `BEFORE UPDATE` trigger that bumps `updated_at = now()` at trigger-fire time, overriding any explicit value sent in the UPDATE. So reassignment writes both timestamps identically:

```js
const updates = {
  assigned_at: nowIso,
  updated_at:  nowIso,
};
```

…but the row actually persists with `updated_at` a few microseconds AFTER `assigned_at`. When the lead loads:

```
_assignedT = 1717234800000
_lastActT  = 1717234800123   // trigger noise — looks like a touch
```

The previous strict check `_lastActT > _assignedT` then returned **true** for every freshly reassigned lead, dropping the entire batch from New as if the telecaller had already touched them.

### Fix

Tolerate up to **60s** between `assigned_at` and `lastActivity` (also `assigned_at` vs `_lastCall`) before treating it as a real telecaller touch.

- Trigger noise: microseconds — well within the 60s window → lead stays in New ✓
- Real call/save: minutes apart from reassignment — well outside 60s → lead drops from New ✓

```js
const TOUCH_TOLERANCE_MS = 60 * 1000;
if (l._lastActT - assignedT > TOUCH_TOLERANCE_MS) return false;
if (l._lastCall) {
  const lastCallT = new Date(l._lastCall.timestamp || 0).getTime();
  if (lastCallT - assignedT > TOUCH_TOLERANCE_MS) return false;
}
```

Preserves all earlier behavior:
- PR #122 — Quick Log save still drops the called lead from New (call timestamp is minutes after assignment)
- PR #124 — Fresh reassignments still surface in New regardless of carried-over status

## Test plan
- [ ] Reassign a batch to chetna → confirm New tab populates with the new assignments
- [ ] Log a call on one → confirm it leaves New
- [ ] Leave a lead untouched for 48h → confirm it ages out of New into All / appropriate tab
- [ ] Confirm Booked / Lost still never show in New

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_