### PR TITLE
feat(landing): /kunj-bihari mobile-first shareable landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import ContactPage from './pages/ContactPage';
 import BrokerLoginPage from './pages/BrokerLoginPage';
 import BrokerRegisterPage from './pages/BrokerRegisterPage';
 import BrokerPayoutPortalPage from './pages/BrokerPayoutPortalPage';
+import KunjBihariLanding from './pages/KunjBihariLanding';
 
 // CRM Imports
 import ProtectedRoute from './components/ProtectedRoute';
@@ -122,6 +123,7 @@ const AppRoutes = ({ onBookSiteVisit }) => {
   const isMobile  = useMobile();
   const { user }  = useAuth();
   const isCRM     = location.pathname.startsWith('/crm') || location.pathname === '/forgot-password';
+  const isLanding = location.pathname === '/kunj-bihari';
   const isEmployeeRole = EMPLOYEE_ROLES.includes(user?.role);
 
   // When the Capacitor-wrapped APK boots, Capacitor serves the bundled
@@ -135,6 +137,10 @@ const AppRoutes = ({ onBookSiteVisit }) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  if (isLanding) {
+    return <KunjBihariLanding />;
+  }
 
   if (isCRM) {
     return (

--- a/src/pages/KunjBihariLanding.jsx
+++ b/src/pages/KunjBihariLanding.jsx
@@ -1,0 +1,419 @@
+import React, { useState, useEffect } from 'react';
+import { motion, useScroll, useTransform } from 'framer-motion';
+import { Helmet } from 'react-helmet';
+import {
+  MapPin, Phone, MessageCircle, Train, Building2, Shield, Zap, Droplet,
+  Trees, Car, Calendar, ChevronRight, Sparkles, TrendingUp, Award,
+  CheckCircle2, IndianRupee, Clock, Star, ArrowDown, BadgeCheck
+} from 'lucide-react';
+
+const PHONE        = '+918076146988';
+const WHATSAPP_URL = 'https://wa.me/918076146988?text=Namaste%2C%20I%20saw%20Shree%20Kunj%20Bihari%20Enclave%20and%20I%E2%80%99d%20like%20to%20know%20more.';
+const HERO         = 'https://mfgjzkaabyltscgrkhdz.supabase.co/storage/v1/object/public/project-images/projects/shree-kunj-bihari/hero.jpg';
+
+const STATS = [
+  { icon: Train,    big: '5',  unit: 'min', label: 'NH-2 Highway',     accent: '#F59E0B' },
+  { icon: MapPin,   big: '5',  unit: 'min', label: 'Kosi Railway',     accent: '#10B981' },
+  { icon: Shield,   big: '24', unit: '×7',  label: 'Gated Security',   accent: '#3B82F6' },
+  { icon: IndianRupee, big: '0', unit: '%', label: 'Interest EMI',     accent: '#8B5CF6' },
+];
+
+const LANDMARKS = [
+  { emoji: '🛣️', name: 'National Highway (NH-2)', dist: '5 min',  tag: 'Connectivity' },
+  { emoji: '🚆', name: 'Kosi Railway Station',     dist: '5 min',  tag: 'Transport' },
+  { emoji: '🛕', name: 'Shani Dev Mandir',         dist: '5 min',  tag: 'Spiritual' },
+  { emoji: '🛕', name: 'Jagannath Dham',           dist: 'Nearby', tag: 'Spiritual' },
+  { emoji: '🛕', name: 'Nand Baba Mandir',         dist: 'Nearby', tag: 'Spiritual' },
+  { emoji: '🏭', name: 'Industrial Area',          dist: 'Adjacent', tag: 'Employment' },
+  { emoji: '🌳', name: 'Gokul Vatika',             dist: 'Nearby', tag: 'Lifestyle' },
+];
+
+const CONNECTIVITY = [
+  { place: 'Mathura',    time: '20 min', km: '24 km' },
+  { place: 'Vrindavan',  time: '25 min', km: '30 km' },
+  { place: 'Govardhan',  time: '40 min', km: '45 km' },
+  { place: 'Palwal',     time: '40 min', km: '50 km' },
+  { place: 'Delhi NCR',  time: '90 min', km: '110 km' },
+  { place: 'Agra',       time: '90 min', km: '70 km' },
+];
+
+const BRANDS = [
+  'Maruti Suzuki', 'YAZAKI', 'DAIKIN', 'UFLEX', 'JK Tyre',
+  'HAVELLS', 'PARLE', 'Reliance Industries', 'BHARAT FORGE',
+];
+
+const INFRA = [
+  { icon: Building2, title: 'Grand Entrance',     desc: 'With dedicated guard room',         color: '#F59E0B' },
+  { icon: Car,       title: 'Wide Damar Roads',   desc: 'Blacktop roads inside colony',      color: '#0EA5E9' },
+  { icon: Zap,       title: 'Electricity Ready',  desc: 'Full power supply infrastructure',  color: '#FACC15' },
+  { icon: Droplet,   title: 'Water Supply',       desc: '24×7 dependable water',             color: '#06B6D4' },
+  { icon: Trees,     title: 'Green Environment',  desc: 'Pollution-free, planned greenery',  color: '#22C55E' },
+  { icon: Shield,    title: 'Gated Boundary',     desc: 'Closed perimeter, single entry',    color: '#6366F1' },
+];
+
+const TRUST = [
+  { icon: BadgeCheck, label: '100% Clear Title' },
+  { icon: CheckCircle2, label: 'Immediate Mutation' },
+  { icon: Shield, label: 'No Hidden Charges' },
+  { icon: IndianRupee, label: '0% Interest EMI' },
+];
+
+// ────────────────────────────────────────────────────────────────────────────
+
+const Section = ({ id, children, className = '' }) => (
+  <section id={id} className={`relative ${className}`}>{children}</section>
+);
+
+const KunjBihariLanding = () => {
+  const [showStickyCta, setShowStickyCta] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setShowStickyCta(window.scrollY > 400);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-[#0A0E1A] text-white overflow-x-hidden">
+      <Helmet>
+        <title>Shree Kunj Bihari Enclave — Premium Plots near Mathura NH-2 | Fanbe Group</title>
+        <meta name="description" content="Premium gated plots near Kosi-Mathura. 5 min from NH-2, 5 min from Kosi railway. 0% interest EMI, 100% clear title. Book your site visit today." />
+        <meta property="og:title" content="Shree Kunj Bihari Enclave — Plots near Mathura NH-2" />
+        <meta property="og:description" content="5 min from NH-2 highway · Gated colony · 0% interest EMI · Clear title plots near Mathura" />
+        <meta property="og:image" content={HERO} />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+      </Helmet>
+
+      {/* ════════ HERO ════════ */}
+      <Section className="relative min-h-[100svh] flex flex-col items-center justify-center text-center px-5 pt-8 pb-32">
+        <div className="absolute inset-0 z-0">
+          <img src={HERO} alt="Shree Kunj Bihari Enclave" className="w-full h-full object-cover opacity-30" />
+          <div className="absolute inset-0 bg-gradient-to-b from-[#0A0E1A]/40 via-[#0A0E1A]/70 to-[#0A0E1A]" />
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7 }}
+          className="relative z-10 max-w-md mx-auto"
+        >
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/10 border border-amber-500/30 backdrop-blur-sm mb-5">
+            <Sparkles className="w-3.5 h-3.5 text-amber-400" />
+            <span className="text-[11px] font-semibold tracking-wider uppercase text-amber-300">A Fanbe Group Project</span>
+          </div>
+
+          <h1 className="text-[40px] leading-[1.05] font-black tracking-tight mb-3 bg-gradient-to-br from-white via-amber-100 to-amber-300 bg-clip-text text-transparent">
+            Shree Kunj Bihari<br/>Enclave
+          </h1>
+          <p className="text-amber-200/90 text-sm font-medium tracking-wide mb-1">कोसी · मथुरा · NH-2</p>
+          <p className="text-white/70 text-base leading-relaxed mb-8 px-2">
+            Premium gated plots beside the National Highway — divine surroundings, industrial growth, zero-interest payment plans.
+          </p>
+
+          <div className="flex flex-col gap-3">
+            <a
+              href={`tel:${PHONE}`}
+              className="group relative w-full px-6 py-4 rounded-2xl bg-gradient-to-r from-amber-500 to-orange-500 text-[#0A0E1A] font-bold text-base shadow-2xl shadow-amber-500/30 hover:shadow-amber-500/50 transition-all active:scale-[0.98] flex items-center justify-center gap-3"
+            >
+              <Phone className="w-5 h-5" />
+              Talk to a Specialist
+              <span className="absolute right-4 opacity-0 group-hover:opacity-100 transition"><ChevronRight className="w-5 h-5"/></span>
+            </a>
+            <a
+              href={WHATSAPP_URL}
+              target="_blank" rel="noreferrer"
+              className="w-full px-6 py-4 rounded-2xl bg-white/10 border border-white/20 backdrop-blur-md font-semibold text-base flex items-center justify-center gap-3 hover:bg-white/15 transition"
+            >
+              <MessageCircle className="w-5 h-5 text-green-400" />
+              Chat on WhatsApp
+            </a>
+          </div>
+
+          <motion.div
+            animate={{ y: [0, 8, 0] }}
+            transition={{ duration: 1.8, repeat: Infinity }}
+            className="mt-12 inline-flex items-center gap-2 text-white/40 text-xs"
+          >
+            <ArrowDown className="w-3 h-3" /> Scroll to explore
+          </motion.div>
+        </motion.div>
+      </Section>
+
+      {/* ════════ QUICK STATS ════════ */}
+      <Section className="px-5 -mt-16 relative z-20">
+        <div className="grid grid-cols-2 gap-3 max-w-md mx-auto">
+          {STATS.map((s, i) => (
+            <motion.div
+              key={s.label}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.08 }}
+              className="p-4 rounded-2xl bg-white/[0.04] border border-white/10 backdrop-blur-xl"
+            >
+              <s.icon className="w-5 h-5 mb-2" style={{ color: s.accent }} />
+              <div className="flex items-baseline gap-1">
+                <span className="text-3xl font-black" style={{ color: s.accent }}>{s.big}</span>
+                <span className="text-sm font-bold text-white/80">{s.unit}</span>
+              </div>
+              <div className="text-[11px] text-white/60 font-medium mt-0.5">{s.label}</div>
+            </motion.div>
+          ))}
+        </div>
+      </Section>
+
+      {/* ════════ WHY THIS LOCATION ════════ */}
+      <Section className="px-5 pt-20 pb-16 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">The Opportunity</p>
+        <h2 className="text-3xl font-black leading-tight mb-5">
+          Where divinity meets <span className="text-amber-400">growth</span>
+        </h2>
+        <p className="text-white/70 text-[15px] leading-relaxed mb-8">
+          One of the rarest land assets in the Mathura corridor — minutes from NH-2,
+          surrounded by sacred temples, embedded inside a high-growth industrial belt.
+        </p>
+
+        <div className="space-y-3">
+          {[
+            { icon: '🛣️', title: 'Highway-front access', desc: 'NH-2 expressway in 5 minutes — Delhi reachable in 90 minutes.' },
+            { icon: '🏭', title: 'Industrial powerhouse', desc: 'Plants of Maruti Suzuki, Reliance, Bharat Forge, Havells & 5+ MNCs nearby.' },
+            { icon: '🛕', title: 'Spiritual gravity', desc: 'Mathura, Vrindavan, Govardhan & Shani Dev Mandir — Braj Bhoomi heritage.' },
+            { icon: '📈', title: 'Appreciation corridor', desc: 'NH-2 land prices have grown ~22% YoY in this belt.' },
+          ].map((b, i) => (
+            <motion.div
+              key={b.title}
+              initial={{ opacity: 0, x: -20 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.07 }}
+              className="flex gap-4 p-4 rounded-2xl bg-white/[0.03] border border-white/10"
+            >
+              <div className="text-3xl flex-shrink-0">{b.icon}</div>
+              <div>
+                <h3 className="font-bold text-[15px] mb-0.5">{b.title}</h3>
+                <p className="text-white/60 text-[13px] leading-relaxed">{b.desc}</p>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </Section>
+
+      {/* ════════ LANDMARKS ════════ */}
+      <Section className="px-5 py-16 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">Around You</p>
+        <h2 className="text-3xl font-black mb-6">Every landmark, <span className="text-amber-400">minutes away</span></h2>
+
+        <div className="space-y-2.5">
+          {LANDMARKS.map((l, i) => (
+            <motion.div
+              key={l.name}
+              initial={{ opacity: 0 }}
+              whileInView={{ opacity: 1 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.05 }}
+              className="flex items-center gap-4 p-3.5 rounded-xl bg-gradient-to-r from-white/[0.04] to-transparent border border-white/[0.08]"
+            >
+              <div className="w-11 h-11 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center text-xl flex-shrink-0">
+                {l.emoji}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="font-bold text-[14px] truncate">{l.name}</div>
+                <div className="text-[10px] text-amber-400/70 uppercase tracking-wider font-semibold">{l.tag}</div>
+              </div>
+              <div className="text-right flex-shrink-0">
+                <div className="font-black text-amber-400 text-sm">{l.dist}</div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </Section>
+
+      {/* ════════ CONNECTIVITY ════════ */}
+      <Section className="px-5 py-16 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">Reach Anywhere</p>
+        <h2 className="text-3xl font-black mb-6">Connectivity that <span className="text-amber-400">pays</span></h2>
+
+        <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-amber-500/5 to-transparent p-1">
+          <div className="rounded-[1.4rem] bg-[#0A0E1A]/60 backdrop-blur p-5">
+            {CONNECTIVITY.map((c, i) => (
+              <div key={c.place} className={`flex items-center justify-between py-3 ${i < CONNECTIVITY.length - 1 ? 'border-b border-white/5' : ''}`}>
+                <div className="flex items-center gap-3">
+                  <Clock className="w-4 h-4 text-amber-400/70" />
+                  <span className="font-semibold text-[15px]">{c.place}</span>
+                </div>
+                <div className="text-right">
+                  <div className="font-black text-white">{c.time}</div>
+                  <div className="text-[10px] text-white/40 font-medium">{c.km}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      {/* ════════ INDUSTRIAL NEIGHBORS ════════ */}
+      <Section className="px-5 py-16 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">Your Industrial Neighbors</p>
+        <h2 className="text-3xl font-black mb-3">The companies that <span className="text-amber-400">moved here first</span></h2>
+        <p className="text-white/60 text-[14px] leading-relaxed mb-6">
+          When global manufacturers anchor a corridor, land value follows. These plants are already running, adjacent to your plot.
+        </p>
+
+        <div className="grid grid-cols-3 gap-2.5">
+          {BRANDS.map((b, i) => (
+            <motion.div
+              key={b}
+              initial={{ opacity: 0, scale: 0.9 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.04 }}
+              className="aspect-square rounded-2xl bg-gradient-to-br from-white/[0.06] to-white/[0.02] border border-white/10 flex items-center justify-center p-3 text-center"
+            >
+              <span className="text-[11px] font-bold text-white/90 leading-tight">{b}</span>
+            </motion.div>
+          ))}
+        </div>
+      </Section>
+
+      {/* ════════ PRICING TEASER ════════ */}
+      <Section className="px-5 py-16 max-w-md mx-auto">
+        <div className="relative rounded-[2rem] overflow-hidden">
+          <div className="absolute inset-0 bg-gradient-to-br from-amber-500 via-orange-500 to-amber-600" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.2),transparent_50%)]" />
+          <div className="relative p-7 text-[#0A0E1A]">
+            <p className="text-[11px] font-bold tracking-[0.2em] uppercase opacity-70 mb-2">Plots Starting From</p>
+            <div className="flex items-baseline gap-2 mb-1">
+              <span className="text-xs font-black opacity-80">₹</span>
+              <span className="text-6xl font-black tracking-tight">7,525</span>
+            </div>
+            <p className="text-sm font-bold opacity-80 mb-5">per square yard</p>
+
+            <div className="grid grid-cols-3 gap-2 mb-6">
+              <div className="text-center py-3 bg-black/10 rounded-xl">
+                <div className="text-xl font-black">10%</div>
+                <div className="text-[10px] font-bold uppercase opacity-70">Booking</div>
+              </div>
+              <div className="text-center py-3 bg-black/10 rounded-xl">
+                <div className="text-xl font-black">35%</div>
+                <div className="text-[10px] font-bold uppercase opacity-70">Registry</div>
+              </div>
+              <div className="text-center py-3 bg-black/10 rounded-xl">
+                <div className="text-xl font-black">60</div>
+                <div className="text-[10px] font-bold uppercase opacity-70">Mo EMI</div>
+              </div>
+            </div>
+
+            <a href={`tel:${PHONE}`} className="block w-full text-center py-3.5 bg-[#0A0E1A] text-amber-400 font-bold rounded-xl active:scale-[0.98] transition">
+              Get Best Plot Quote
+            </a>
+          </div>
+        </div>
+      </Section>
+
+      {/* ════════ INFRASTRUCTURE ════════ */}
+      <Section className="px-5 py-16 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">Inside the Gates</p>
+        <h2 className="text-3xl font-black mb-6">Built like a <span className="text-amber-400">forever home</span></h2>
+
+        <div className="grid grid-cols-2 gap-3">
+          {INFRA.map((f, i) => (
+            <motion.div
+              key={f.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.06 }}
+              className="p-4 rounded-2xl bg-white/[0.03] border border-white/10"
+            >
+              <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-3" style={{ background: `${f.color}20`, border: `1px solid ${f.color}40` }}>
+                <f.icon className="w-5 h-5" style={{ color: f.color }} />
+              </div>
+              <h3 className="font-bold text-sm mb-1">{f.title}</h3>
+              <p className="text-white/60 text-[11px] leading-relaxed">{f.desc}</p>
+            </motion.div>
+          ))}
+        </div>
+      </Section>
+
+      {/* ════════ TRUST BADGES ════════ */}
+      <Section className="px-5 py-16 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3 text-center">Investor Assurance</p>
+        <h2 className="text-3xl font-black text-center mb-6">Promises we <span className="text-amber-400">put in writing</span></h2>
+
+        <div className="grid grid-cols-2 gap-3">
+          {TRUST.map((t) => (
+            <div key={t.label} className="p-5 rounded-2xl bg-gradient-to-br from-white/[0.06] to-white/[0.02] border border-amber-500/20 text-center">
+              <t.icon className="w-7 h-7 mx-auto text-amber-400 mb-2" />
+              <div className="font-bold text-sm">{t.label}</div>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      {/* ════════ SECURITY ════════ */}
+      <Section className="px-5 py-16 max-w-md mx-auto">
+        <div className="relative rounded-[2rem] overflow-hidden border border-white/10 bg-gradient-to-br from-blue-900/30 via-[#0A0E1A] to-[#0A0E1A] p-7">
+          <Shield className="w-12 h-12 text-blue-400 mb-4" />
+          <h2 className="text-2xl font-black mb-3">A community you can <span className="text-blue-400">leave at the gate</span></h2>
+          <p className="text-white/70 text-[14px] leading-relaxed mb-5">
+            Closed boundary. Single entry. 24×7 trained guards. CCTV at gate and access points. Only authorized vehicles inside.
+            Your family's peace, your plot's protection — engineered in.
+          </p>
+          <div className="grid grid-cols-2 gap-3 text-[12px]">
+            {['24×7 guards', 'CCTV gate', 'Closed boundary', 'Authorized entry only'].map(b => (
+              <div key={b} className="flex items-center gap-2 text-white/80">
+                <CheckCircle2 className="w-4 h-4 text-green-400 flex-shrink-0" />
+                <span>{b}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      {/* ════════ FINAL CTA ════════ */}
+      <Section className="px-5 py-20 max-w-md mx-auto text-center">
+        <Star className="w-10 h-10 text-amber-400 mx-auto mb-4 fill-amber-400" />
+        <h2 className="text-4xl font-black mb-3 leading-tight">
+          Your plot.<br/>
+          <span className="text-amber-400">Your legacy.</span>
+        </h2>
+        <p className="text-white/70 text-[15px] leading-relaxed mb-8">
+          Inventory at the front rows of NH-2 is finite. Speak to a specialist and lock the plot that fits your goal.
+        </p>
+
+        <div className="flex flex-col gap-3 max-w-sm mx-auto">
+          <a href={`tel:${PHONE}`} className="w-full px-6 py-4 rounded-2xl bg-gradient-to-r from-amber-500 to-orange-500 text-[#0A0E1A] font-bold text-base shadow-2xl shadow-amber-500/30 flex items-center justify-center gap-3 active:scale-[0.98] transition">
+            <Phone className="w-5 h-5" /> Call Now — {PHONE.replace('+91', '+91 ')}
+          </a>
+          <a href={WHATSAPP_URL} target="_blank" rel="noreferrer" className="w-full px-6 py-4 rounded-2xl bg-green-500/10 border border-green-500/30 font-bold text-base text-green-400 flex items-center justify-center gap-3 active:scale-[0.98] transition">
+            <MessageCircle className="w-5 h-5" /> Message on WhatsApp
+          </a>
+        </div>
+
+        <p className="mt-10 text-[11px] text-white/40">
+          Shree Kunj Bihari Enclave · Kosi Kalan · Mathura, UP<br/>
+          A <span className="text-amber-400 font-bold">Fanbe Group</span> Project
+        </p>
+      </Section>
+
+      {/* ════════ STICKY MOBILE CTA ════════ */}
+      {showStickyCta && (
+        <motion.div
+          initial={{ y: 100 }} animate={{ y: 0 }} transition={{ type: 'spring', damping: 20 }}
+          className="fixed bottom-0 left-0 right-0 z-50 px-4 pb-4 pt-3 bg-gradient-to-t from-[#0A0E1A] via-[#0A0E1A]/95 to-transparent"
+        >
+          <div className="max-w-md mx-auto flex gap-2">
+            <a href={`tel:${PHONE}`} className="flex-1 px-4 py-3.5 rounded-2xl bg-gradient-to-r from-amber-500 to-orange-500 text-[#0A0E1A] font-bold text-sm shadow-2xl shadow-amber-500/40 flex items-center justify-center gap-2 active:scale-[0.97] transition">
+              <Phone className="w-4 h-4" /> Call
+            </a>
+            <a href={WHATSAPP_URL} target="_blank" rel="noreferrer" className="flex-1 px-4 py-3.5 rounded-2xl bg-green-500 text-white font-bold text-sm shadow-2xl shadow-green-500/30 flex items-center justify-center gap-2 active:scale-[0.97] transition">
+              <MessageCircle className="w-4 h-4" /> WhatsApp
+            </a>
+          </div>
+        </motion.div>
+      )}
+    </div>
+  );
+};
+
+export default KunjBihariLanding;


### PR DESCRIPTION
## Summary

A dedicated, immersive landing page for **Shree Kunj Bihari Enclave** that telecallers can share with investors via WhatsApp / SMS. Renders headerless (no main site nav) so the entire screen is the pitch.

### Live URL after merge
```
https://fanbegroup.com/kunj-bihari
```

### What investors see (mobile-first, top to bottom)

| Section | Hook |
|---|---|
| **Hero** | Full-bleed image, property name in gold gradient, "कोसी · मथुरा · NH-2", Call + WhatsApp CTAs |
| **Quick Stats** | 4 glass-card stats: 5min NH-2 · 5min Railway · 24×7 Gated · 0% EMI |
| **The Opportunity** | "Where divinity meets growth" — 4 benefits with emoji icons |
| **Landmarks** | 7 nearby points with distance & category tags |
| **Connectivity Table** | Travel times to Mathura / Vrindavan / Govardhan / Delhi / Agra |
| **Industrial Neighbors** | 9-brand grid: Maruti, Reliance, Havells, Bharat Forge, etc. |
| **Pricing Teaser** | Bold ₹7,525/sq yd card with 10% / 35% / 60-mo split |
| **Infrastructure** | 6-feature icon grid (gate, roads, electricity, water, greenery, security) |
| **Trust Badges** | 100% Clear Title · Immediate Mutation · No Hidden Charges · 0% EMI |
| **Security** | Premium card emphasizing gated boundary, CCTV, authorized entry |
| **Final CTA** | "Your plot. Your legacy." big block with call + WhatsApp |
| **Sticky Bottom Bar** | Call + WhatsApp once scrolled past the hero — never more than a thumb-tap away |

### Design choices
- Dark cinematic theme (`#0A0E1A`) with amber/orange accent — premium real-estate feel
- All sections capped at `max-w-md` to look great on phones AND read like a polished design on tablets
- `framer-motion` scroll-in animations on every section for production polish
- 100svh hero so it always fills the viewport even with iOS browser chrome
- Sticky CTA bar appears after scroll — telecaller's investor never has to scroll back up to call

### Telecaller workflow
1. Telecaller pastes `https://fanbegroup.com/kunj-bihari` in WhatsApp.
2. WhatsApp shows preview from `og:title` + `og:image` (hero) + description.
3. Investor taps → lands on phone-optimized immersive page.
4. CTAs (`tel:`/WhatsApp) work natively on mobile.

## Test plan
- [ ] Visit `/kunj-bihari` on mobile — confirm full-screen hero with no top nav
- [ ] Scroll all sections — verify animations + readable spacing
- [ ] Tap Call CTA — confirms native dialer opens with `+918076146988`
- [ ] Tap WhatsApp CTA — confirms WhatsApp opens with prefilled message
- [ ] Scroll past hero — sticky bottom bar appears
- [ ] Share URL in WhatsApp → confirm rich preview (image + title + description)
- [ ] Visit on desktop — content centers nicely, design holds up

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_