### PR TITLE
fix(vercel): SPA fallback so /kunj-bihari and friends stop 404-ing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,7 @@
   "rewrites": [
     { "source": "/crm",          "destination": "/index.html" },
     { "source": "/crm/",         "destination": "/index.html" },
-    { "source": "/crm/:path*",   "destination": "/index.html" }
+    { "source": "/crm/:path*",   "destination": "/index.html" },
+    { "source": "/((?!api/|assets/|.*\\..*).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary

`https://fanbegroup.com/kunj-bihari` returned a Vercel **404 NOT_FOUND** because the existing `vercel.json` only rewrites `/crm/*` to `index.html`. Any other SPA route — `/kunj-bihari`, and likely `/about`, `/projects/:slug`, `/broker/login`, etc. on direct loads — falls through to the static file handler, finds nothing, and 404s.

### Change

Add a catch-all rewrite that hands every non-asset, non-API path to `index.html` so React Router handles it:

```json
{ "source": "/((?!api/|assets/|.*\\..*).*)", "destination": "/index.html" }
```

The negative lookahead skips:
- `/api/*` — future API routes
- `/assets/*` — Vite bundles
- Anything with a `.` — static files like `favicon.svg`, `sw.js`, `manifest.webmanifest`

Everything else routes to `index.html`. The original `/crm/*` rewrites stay first for explicit intent (the catch-all would have caught them anyway).

## Test plan
- [ ] Deploy → visit `https://fanbegroup.com/kunj-bihari` directly — landing renders, no 404
- [ ] Hard refresh on `/about`, `/projects`, `/broker/login` — all load via React Router
- [ ] `/favicon.svg`, `/manifest.webmanifest`, `/sw.js` still serve as static files (no rewrite)
- [ ] `/crm/login`, `/crm/sales/my-leads` continue to work (unchanged)

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_