### PR TITLE
feat(landing): ₹100Cr cinematic 3D experience for /kunj-bihari

### DIFF
--- a/src/pages/KunjBihariLanding.jsx
+++ b/src/pages/KunjBihariLanding.jsx
@@ -1,40 +1,39 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { motion, useScroll, useTransform } from 'framer-motion';
+import { motion, useScroll, useTransform, useSpring, useInView, useMotionValue } from 'framer-motion';
 import { Helmet } from 'react-helmet';
 import {
   MapPin, Train, Building2, Shield, Zap, Droplet, Trees, Car,
-  Calendar, ChevronRight, Sparkles, TrendingUp, Award, CheckCircle2,
-  IndianRupee, Clock, Star, ArrowDown, BadgeCheck, Compass, Layers,
-  Mountain
+  Sparkles, CheckCircle2, IndianRupee, Clock, Star, ArrowDown,
+  BadgeCheck, Compass, Layers, Mountain, TrendingUp, Award, Crown,
+  Gem, ChevronUp
 } from 'lucide-react';
 
+// ────────────────────────────────────────────────────────────────────────────
+// Configuration
 const HERO = 'https://mfgjzkaabyltscgrkhdz.supabase.co/storage/v1/object/public/project-images/projects/shree-kunj-bihari/hero.jpg';
-
-// Approx coordinates near Kosi Kalan, Mathura — Shree Kunj Bihari Enclave
 const LAT = 27.7910;
 const LNG = 77.4385;
 const MAPS_LINK = 'https://maps.app.goo.gl/AdZxBk4tLRGceHAn8';
 const SATELLITE_EMBED = `https://maps.google.com/maps?q=${LAT},${LNG}&t=k&z=16&ie=UTF8&iwloc=&output=embed`;
 const HYBRID_EMBED    = `https://maps.google.com/maps?q=${LAT},${LNG}&t=h&z=15&ie=UTF8&iwloc=&output=embed`;
 
-// NH-2 corridor — places in order with approximate distance from Kosi
 const CORRIDOR = [
-  { name: 'Delhi',     dist: '+110 km', side: 'left'  },
-  { name: 'Badarpur',  dist: '+95 km',  side: 'left'  },
-  { name: 'Palwal',    dist: '+60 km',  side: 'left'  },
-  { name: 'Hodal',     dist: '+30 km',  side: 'left'  },
-  { name: 'KOSI',      dist: 'YOU ARE HERE',     side: 'pin', highlight: true },
-  { name: 'Chhata',    dist: '+10 km',  side: 'right' },
-  { name: 'Akbarpur',  dist: '+18 km',  side: 'right' },
-  { name: 'Vrindavan', dist: '+30 km',  side: 'right' },
-  { name: 'Mathura',   dist: '+24 km',  side: 'right' },
+  { name: 'Delhi NCR',  dist: '110 km', side: 'left',  drive: '90 min' },
+  { name: 'Badarpur',   dist: '95 km',  side: 'left',  drive: '80 min' },
+  { name: 'Palwal',     dist: '60 km',  side: 'left',  drive: '55 min' },
+  { name: 'Hodal',      dist: '30 km',  side: 'left',  drive: '30 min' },
+  { name: 'KOSI',       dist: '0 km',   side: 'pin',   highlight: true, drive: 'HERE' },
+  { name: 'Chhata',     dist: '10 km',  side: 'right', drive: '10 min' },
+  { name: 'Akbarpur',   dist: '18 km',  side: 'right', drive: '15 min' },
+  { name: 'Vrindavan',  dist: '30 km',  side: 'right', drive: '25 min' },
+  { name: 'Mathura',    dist: '24 km',  side: 'right', drive: '20 min' },
 ];
 
 const STATS = [
-  { icon: Train,       big: '5',  unit: 'min', label: 'NH-2 Highway',  accent: '#F59E0B' },
-  { icon: MapPin,      big: '5',  unit: 'min', label: 'Kosi Railway',  accent: '#10B981' },
-  { icon: Shield,      big: '24', unit: '×7',  label: 'Gated Security', accent: '#3B82F6' },
-  { icon: IndianRupee, big: '0',  unit: '%',   label: 'Interest EMI',  accent: '#8B5CF6' },
+  { icon: Train,       big: '5',   unit: 'min', label: 'NH-2 Highway',   accent: '#F59E0B' },
+  { icon: MapPin,      big: '5',   unit: 'min', label: 'Kosi Railway',   accent: '#10B981' },
+  { icon: Shield,      big: '24',  unit: '×7',  label: 'Gated Security', accent: '#3B82F6' },
+  { icon: IndianRupee, big: '0',   unit: '%',   label: 'Interest EMI',   accent: '#8B5CF6' },
 ];
 
 const LANDMARKS = [
@@ -47,18 +46,18 @@ const LANDMARKS = [
   { emoji: '🌳', name: 'Gokul Vatika',             dist: 'Nearby', tag: 'Lifestyle' },
 ];
 
-const CONNECTIVITY = [
-  { place: 'Mathura',    time: '20 min', km: '24 km' },
-  { place: 'Vrindavan',  time: '25 min', km: '30 km' },
-  { place: 'Govardhan',  time: '40 min', km: '45 km' },
-  { place: 'Palwal',     time: '40 min', km: '50 km' },
-  { place: 'Delhi NCR',  time: '90 min', km: '110 km' },
-  { place: 'Agra',       time: '90 min', km: '70 km' },
-];
-
 const BRANDS = [
   'Maruti Suzuki', 'YAZAKI', 'DAIKIN', 'UFLEX', 'JK Tyre',
-  'HAVELLS', 'PARLE', 'Reliance Industries', 'BHARAT FORGE',
+  'HAVELLS', 'PARLE', 'Reliance', 'BHARAT FORGE',
+];
+
+const PLOTS = [
+  { size: 50,  total: 376250,  emi: 5644,  highlight: false },
+  { size: 80,  total: 602000,  emi: 9030,  highlight: false },
+  { size: 100, total: 752500,  emi: 11287, highlight: true  },
+  { size: 150, total: 1128750, emi: 16931, highlight: false },
+  { size: 200, total: 1505000, emi: 22575, highlight: false },
+  { size: 250, total: 1881250, emi: 28219, highlight: false },
 ];
 
 const INFRA = [
@@ -77,76 +76,271 @@ const TRUST = [
   { icon: IndianRupee,  label: '0% Interest EMI' },
 ];
 
-const Section = ({ id, children, className = '' }) => (
-  <section id={id} className={`relative ${className}`}>{children}</section>
-);
+// ────────────────────────────────────────────────────────────────────────────
+// Particles — gold ambient drift
+const Particles = ({ count = 30 }) => {
+  const seeds = React.useMemo(
+    () => Array.from({ length: count }, (_, i) => ({
+      x: Math.random() * 100,
+      y: Math.random() * 100,
+      d: 8 + Math.random() * 14,
+      s: 1 + Math.random() * 3,
+      o: 0.15 + Math.random() * 0.45,
+      delay: Math.random() * 8,
+      id: i,
+    })),
+    [count]
+  );
+  return (
+    <div className="absolute inset-0 pointer-events-none overflow-hidden">
+      {seeds.map((p) => (
+        <motion.div
+          key={p.id}
+          className="absolute rounded-full"
+          style={{
+            left: `${p.x}%`,
+            top: `${p.y}%`,
+            width: p.s,
+            height: p.s,
+            background: 'radial-gradient(circle, rgba(252,211,77,0.9), rgba(252,211,77,0) 70%)',
+            opacity: p.o,
+          }}
+          animate={{ y: [0, -40, 0], opacity: [p.o, p.o * 1.5, p.o] }}
+          transition={{ duration: p.d, repeat: Infinity, delay: p.delay, ease: 'easeInOut' }}
+        />
+      ))}
+    </div>
+  );
+};
+
+// Animated number counter
+const Counter = ({ to, suffix = '', duration = 1.6 }) => {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: '-50px' });
+  const [val, setVal] = useState(0);
+  useEffect(() => {
+    if (!inView) return;
+    const start = performance.now();
+    let raf;
+    const tick = (t) => {
+      const p = Math.min(1, (t - start) / (duration * 1000));
+      const eased = 1 - Math.pow(1 - p, 4); // easeOutQuart
+      setVal(Math.round(to * eased));
+      if (p < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [inView, to, duration]);
+  return (
+    <span ref={ref}>
+      {val.toLocaleString('en-IN')}{suffix}
+    </span>
+  );
+};
+
+// 3D tilt wrapper (touch-aware)
+const Tilt3D = ({ children, intensity = 8, className = '' }) => {
+  const rx = useMotionValue(0);
+  const ry = useMotionValue(0);
+  const sx = useSpring(rx, { stiffness: 220, damping: 18 });
+  const sy = useSpring(ry, { stiffness: 220, damping: 18 });
+  const handle = (e) => {
+    const r = e.currentTarget.getBoundingClientRect();
+    const x = ((e.touches?.[0]?.clientX ?? e.clientX) - r.left) / r.width;
+    const y = ((e.touches?.[0]?.clientY ?? e.clientY) - r.top) / r.height;
+    ry.set((x - 0.5) * intensity * 2);
+    rx.set((0.5 - y) * intensity * 2);
+  };
+  const reset = () => { rx.set(0); ry.set(0); };
+  return (
+    <motion.div
+      className={className}
+      onMouseMove={handle}
+      onTouchMove={handle}
+      onMouseLeave={reset}
+      onTouchEnd={reset}
+      style={{
+        rotateX: sx, rotateY: sy,
+        transformStyle: 'preserve-3d', transformPerspective: 1000,
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+// ────────────────────────────────────────────────────────────────────────────
 
 const KunjBihariLanding = () => {
+  // Hero parallax
   const heroRef = useRef(null);
-  const { scrollYProgress } = useScroll({ target: heroRef, offset: ['start start', 'end start'] });
-  const heroY    = useTransform(scrollYProgress, [0, 1], [0, 120]);
-  const heroOpac = useTransform(scrollYProgress, [0, 0.7, 1], [1, 0.6, 0]);
+  const { scrollYProgress: heroProg } = useScroll({ target: heroRef, offset: ['start start', 'end start'] });
+  const heroBgY    = useTransform(heroProg, [0, 1], [0, 180]);
+  const heroBgScale = useTransform(heroProg, [0, 1], [1.05, 1.25]);
+  const heroOpac    = useTransform(heroProg, [0, 0.6, 1], [1, 0.6, 0]);
+  const heroTitleY  = useTransform(heroProg, [0, 1], [0, -60]);
+
+  // Sticky NH-2 journey
+  const journeyRef = useRef(null);
+  const { scrollYProgress: jProg } = useScroll({ target: journeyRef, offset: ['start start', 'end end'] });
+  const carY = useTransform(jProg, [0, 1], ['0%', '100%']);
+
+  // Satellite section flyover effect
+  const mapRef = useRef(null);
+  const { scrollYProgress: mProg } = useScroll({ target: mapRef, offset: ['start end', 'end start'] });
+  const mapScale = useTransform(mProg, [0, 0.5, 1], [0.85, 1, 1.05]);
+  const mapRotZ  = useTransform(mProg, [0, 1], [-2, 2]);
 
   const [mapType, setMapType] = useState('satellite');
   const mapSrc = mapType === 'satellite' ? SATELLITE_EMBED : HYBRID_EMBED;
 
+  // Reveal advisor chip after scrolling past hero
+  const [showAdvisorChip, setShowAdvisorChip] = useState(false);
+  useEffect(() => {
+    const onScroll = () => setShowAdvisorChip(window.scrollY > 500);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
   return (
-    <div className="min-h-screen bg-[#05070D] text-white overflow-x-hidden">
+    <div className="min-h-screen bg-[#030509] text-white overflow-x-hidden" style={{ scrollBehavior: 'smooth' }}>
       <Helmet>
-        <title>Shree Kunj Bihari Enclave — Premium Plots near Mathura NH-2 | Fanbe Group</title>
-        <meta name="description" content="Premium gated plots beside NH-2, near Kosi-Mathura. Industrial belt + spiritual heritage + highway access. Clear title, immediate mutation." />
-        <meta property="og:title" content="Shree Kunj Bihari Enclave — Plots near Mathura NH-2" />
-        <meta property="og:description" content="5 min from NH-2 highway · Gated colony · Clear title plots near Mathura" />
+        <title>Shree Kunj Bihari Enclave — A ₹100 Cr Project | Fanbe Group</title>
+        <meta name="description" content="A flagship ₹100 Crore gated development beside NH-2, near Kosi-Mathura. Industrial growth · Spiritual heritage · Highway access." />
+        <meta property="og:title" content="Shree Kunj Bihari Enclave — A ₹100 Cr Development on NH-2" />
+        <meta property="og:description" content="Premium plots beside the National Highway, Kosi-Mathura. By Fanbe Group." />
         <meta property="og:image" content={HERO} />
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+        <style>{`
+          @keyframes marquee { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+          @keyframes pulseRing { 0% { transform: scale(0.7); opacity: 0.9; } 100% { transform: scale(2.4); opacity: 0; } }
+          @keyframes shine { 0% { transform: translateX(-150%); } 60%, 100% { transform: translateX(150%); } }
+          .gold-text {
+            background: linear-gradient(135deg, #FCD34D 0%, #F59E0B 35%, #FCD34D 50%, #F59E0B 65%, #FCD34D 100%);
+            background-size: 200% 200%;
+            -webkit-background-clip: text; background-clip: text;
+            -webkit-text-fill-color: transparent;
+            animation: shine 5s ease-in-out infinite;
+          }
+        `}</style>
       </Helmet>
 
-      {/* ════════ HERO (parallax) ════════ */}
-      <Section id="hero" className="relative min-h-[100svh] flex flex-col items-center justify-center text-center px-5 pt-8 pb-20 overflow-hidden">
-        <motion.div ref={heroRef} style={{ y: heroY, opacity: heroOpac }} className="absolute inset-0 z-0">
-          <img src={HERO} alt="Shree Kunj Bihari Enclave" className="w-full h-full object-cover" />
-          <div className="absolute inset-0 bg-gradient-to-b from-[#05070D]/30 via-[#05070D]/60 to-[#05070D]" />
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(245,158,11,0.15),transparent_50%)]" />
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* HERO — cinematic with parallax + particles + animated reveal         */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section ref={heroRef} className="relative min-h-[100svh] flex flex-col items-center justify-center text-center px-5 overflow-hidden">
+        <motion.div style={{ y: heroBgY, scale: heroBgScale, opacity: heroOpac }} className="absolute inset-0 z-0">
+          <img src={HERO} alt="" className="w-full h-full object-cover" />
+          <div className="absolute inset-0 bg-gradient-to-b from-[#030509]/30 via-[#030509]/60 to-[#030509]" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_25%,rgba(245,158,11,0.22),transparent_55%),radial-gradient(circle_at_75%_80%,rgba(139,92,246,0.12),transparent_60%)]" />
         </motion.div>
+        <Particles count={40} />
 
-        <motion.div
-          initial={{ opacity: 0, y: 30 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.8 }}
-          className="relative z-10 max-w-md mx-auto"
-        >
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/10 border border-amber-500/30 backdrop-blur-sm mb-5">
-            <Sparkles className="w-3.5 h-3.5 text-amber-400" />
-            <span className="text-[11px] font-semibold tracking-wider uppercase text-amber-300">A Fanbe Group Project</span>
-          </div>
+        <motion.div style={{ y: heroTitleY }} className="relative z-10 max-w-md mx-auto">
+          {/* ₹100 Cr seal */}
+          <motion.div
+            initial={{ opacity: 0, scale: 0.8, y: -10 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            transition={{ delay: 0.2, type: 'spring', stiffness: 200 }}
+            className="relative inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-amber-500/20 via-amber-400/30 to-amber-500/20 border border-amber-400/50 backdrop-blur-md mb-6"
+          >
+            <Crown className="w-4 h-4 text-amber-300" />
+            <span className="text-[10px] font-black tracking-[0.25em] uppercase gold-text">A ₹100 Crore Development</span>
+            <Crown className="w-4 h-4 text-amber-300" />
+            <span
+              className="absolute -inset-px rounded-full opacity-60"
+              style={{
+                background: 'linear-gradient(120deg, transparent 30%, rgba(252,211,77,0.4) 50%, transparent 70%)',
+                backgroundSize: '200% 100%',
+                animation: 'shine 3.5s infinite',
+                mixBlendMode: 'overlay',
+              }}
+            />
+          </motion.div>
 
-          <h1 className="text-[44px] leading-[1.02] font-black tracking-tight mb-3 bg-gradient-to-br from-white via-amber-100 to-amber-300 bg-clip-text text-transparent">
-            Shree Kunj Bihari<br/>Enclave
-          </h1>
-          <p className="text-amber-200/90 text-sm font-medium tracking-wider mb-2">कोसी · मथुरा · NH-2 कॉरिडोर</p>
-          <p className="text-white/70 text-[15px] leading-relaxed mb-8 px-3">
-            Premium gated plots beside the National Highway — divine surroundings, industrial growth, zero-interest payment plans.
-          </p>
+          {/* Letter-by-letter title */}
+          <motion.h1
+            className="text-[44px] sm:text-[52px] leading-[0.95] font-black tracking-tighter mb-3"
+            initial="hidden" animate="visible"
+            variants={{
+              hidden: {},
+              visible: { transition: { staggerChildren: 0.04, delayChildren: 0.3 } },
+            }}
+          >
+            {'Shree Kunj Bihari'.split('').map((ch, i) => (
+              <motion.span
+                key={`a-${i}`}
+                className="inline-block gold-text"
+                variants={{
+                  hidden: { opacity: 0, y: 30, rotateX: -90 },
+                  visible: { opacity: 1, y: 0, rotateX: 0, transition: { type: 'spring', damping: 12 } },
+                }}
+                style={{ transformOrigin: 'center bottom' }}
+              >
+                {ch === ' ' ? ' ' : ch}
+              </motion.span>
+            ))}
+            <br/>
+            {'Enclave'.split('').map((ch, i) => (
+              <motion.span
+                key={`b-${i}`}
+                className="inline-block bg-gradient-to-br from-white via-amber-100 to-amber-300 bg-clip-text text-transparent"
+                variants={{
+                  hidden: { opacity: 0, y: 30, rotateX: -90 },
+                  visible: { opacity: 1, y: 0, rotateX: 0, transition: { type: 'spring', damping: 12 } },
+                }}
+                style={{ transformOrigin: 'center bottom' }}
+              >
+                {ch}
+              </motion.span>
+            ))}
+          </motion.h1>
+
+          <motion.p
+            initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 1.4 }}
+            className="text-amber-200/90 text-[13px] font-bold tracking-[0.3em] uppercase mb-3"
+          >
+            कोसी · मथुरा · NH-2
+          </motion.p>
+          <motion.p
+            initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 1.6 }}
+            className="text-white/70 text-[15px] leading-relaxed mb-10 px-3"
+          >
+            A flagship ₹100 Crore development beside India's most legendary highway —
+            divinity, industry, and infrastructure converge at one address.
+          </motion.p>
 
           <motion.div
-            animate={{ y: [0, 8, 0] }}
-            transition={{ duration: 2, repeat: Infinity }}
-            className="inline-flex items-center gap-2 text-amber-400/70 text-xs font-medium tracking-wider"
+            initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 2 }}
+            className="flex flex-col items-center gap-3"
           >
-            <ArrowDown className="w-3.5 h-3.5" />
-            <span>EXPLORE THE LOCATION</span>
-            <ArrowDown className="w-3.5 h-3.5" />
+            <motion.div
+              animate={{ y: [0, 8, 0] }}
+              transition={{ duration: 2, repeat: Infinity }}
+              className="inline-flex items-center gap-2 text-amber-400/80 text-[10px] font-bold tracking-[0.3em]"
+            >
+              <ArrowDown className="w-3.5 h-3.5" />
+              <span>SCROLL TO BEGIN THE JOURNEY</span>
+              <ArrowDown className="w-3.5 h-3.5" />
+            </motion.div>
           </motion.div>
         </motion.div>
-      </Section>
+      </section>
 
-      {/* ════════ QUICK STATS ════════ */}
-      <Section className="px-5 -mt-12 relative z-20">
-        <div className="grid grid-cols-2 gap-3 max-w-md mx-auto">
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* FLOATING STATS (3D flip-in)                                          */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="px-5 -mt-16 relative z-30">
+        <div className="grid grid-cols-2 gap-3 max-w-md mx-auto" style={{ perspective: 1000 }}>
           {STATS.map((s, i) => (
             <motion.div
               key={s.label}
-              initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }}
-              transition={{ delay: i * 0.08 }}
-              className="p-4 rounded-2xl bg-white/[0.04] border border-white/10 backdrop-blur-xl"
+              initial={{ opacity: 0, rotateY: -90, z: -100 }}
+              whileInView={{ opacity: 1, rotateY: 0, z: 0 }}
+              viewport={{ once: true, margin: '-30px' }}
+              transition={{ delay: i * 0.1, type: 'spring', damping: 14 }}
+              className="p-4 rounded-2xl bg-gradient-to-br from-white/[0.07] to-white/[0.02] border border-white/15 backdrop-blur-xl shadow-2xl"
+              style={{ transformStyle: 'preserve-3d' }}
             >
               <s.icon className="w-5 h-5 mb-2" style={{ color: s.accent }} />
               <div className="flex items-baseline gap-1">
@@ -157,105 +351,163 @@ const KunjBihariLanding = () => {
             </motion.div>
           ))}
         </div>
-      </Section>
+      </section>
 
-      {/* ════════ NH-2 CORRIDOR (custom SVG-style) ════════ */}
-      <Section className="px-5 pt-20 pb-10 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">The Mathura Corridor</p>
-        <h2 className="text-3xl font-black leading-tight mb-2">
-          On the spine of <span className="text-amber-400">NH-2</span>
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* OPPORTUNITY HIGHLIGHT — animated counters                            */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="px-5 pt-24 pb-12 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">The Numbers</p>
+        <h2 className="text-3xl font-black leading-tight mb-8">
+          A development at <span className="gold-text">scale</span>
         </h2>
-        <p className="text-white/60 text-[14px] leading-relaxed mb-8">
-          The highway that ties Delhi to Agra runs past your front gate.
-        </p>
 
-        <div className="relative rounded-3xl border border-white/10 bg-gradient-to-b from-[#0A0F1C] via-[#0A0F1C] to-[#080B14] p-5 overflow-hidden">
-          {/* highway gradient line */}
-          <div className="absolute left-[50%] top-12 bottom-12 w-[3px] -ml-[1.5px] bg-gradient-to-b from-transparent via-amber-400/40 to-transparent" />
-          {/* dashed highway marker line */}
-          <div className="absolute left-[50%] top-12 bottom-12 w-[1px] -ml-[0.5px]"
-               style={{ backgroundImage: 'linear-gradient(to bottom, rgba(252,211,77,0.6) 50%, transparent 50%)', backgroundSize: '4px 12px' }} />
-          <div className="absolute left-1/2 top-3 -ml-[18px] text-[9px] font-black tracking-[0.25em] text-amber-400/70 bg-[#0A0F1C] px-2">NH-2</div>
+        <div className="grid grid-cols-3 gap-3">
+          {[
+            { v: 100, suffix: 'Cr',  label: 'Project Worth',  prefix: '₹' },
+            { v: 22,  suffix: '%',   label: 'NH-2 Growth/yr', prefix: '+' },
+            { v: 9,   suffix: '+',   label: 'Plot Sizes',     prefix: '' },
+          ].map((n, i) => (
+            <motion.div
+              key={n.label}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className="text-center p-3 rounded-2xl bg-white/[0.03] border border-amber-500/20"
+            >
+              <div className="text-2xl font-black gold-text">
+                {n.prefix}<Counter to={n.v} />{n.suffix}
+              </div>
+              <div className="text-[10px] text-white/50 mt-1 font-medium uppercase tracking-wider">{n.label}</div>
+            </motion.div>
+          ))}
+        </div>
+      </section>
 
-          <div className="relative space-y-2">
-            {CORRIDOR.map((c, i) => (
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* NH-2 STICKY SCROLLYTELLING JOURNEY                                   */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section ref={journeyRef} className="relative" style={{ height: '220vh' }}>
+        <div className="sticky top-0 h-screen flex items-center justify-center px-5 overflow-hidden">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(245,158,11,0.08),transparent_70%)]" />
+
+          <div className="relative max-w-md w-full">
+            <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-2 text-center">The Mathura Corridor</p>
+            <h2 className="text-3xl font-black leading-tight mb-4 text-center">
+              On the spine of <span className="gold-text">NH-2</span>
+            </h2>
+
+            <div className="relative rounded-3xl border border-white/10 bg-gradient-to-b from-[#070A12] via-[#0A0F1C] to-[#070A12] p-5 overflow-hidden" style={{ height: '60vh' }}>
+              {/* Highway */}
+              <div className="absolute left-1/2 top-8 bottom-8 w-1 -ml-0.5 bg-gradient-to-b from-amber-400/0 via-amber-400/30 to-amber-400/0" />
+              <div className="absolute left-1/2 top-8 bottom-8 w-px -ml-px"
+                   style={{ backgroundImage: 'linear-gradient(to bottom, rgba(252,211,77,0.7) 50%, transparent 50%)', backgroundSize: '4px 14px' }} />
+
+              {/* Highway label */}
+              <div className="absolute left-1/2 top-2 -translate-x-1/2 text-[9px] font-black tracking-[0.3em] text-amber-400/80 bg-[#070A12] px-2">
+                NH-2
+              </div>
+
+              {/* Cars travelling */}
               <motion.div
-                key={c.name}
-                initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: true }}
-                transition={{ delay: i * 0.06 }}
-                className="grid grid-cols-2 gap-3 items-center h-10"
+                style={{ top: carY }}
+                className="absolute left-1/2 -translate-x-1/2 z-30"
               >
-                {c.side === 'left' && (
-                  <>
-                    <div className="text-right pr-3">
-                      <div className="font-bold text-[13px]">{c.name}</div>
-                      <div className="text-[10px] text-white/40 font-medium">{c.dist}</div>
-                    </div>
-                    <div />
-                  </>
-                )}
-                {c.side === 'pin' && (
-                  <>
-                    <div />
-                    <div />
-                  </>
-                )}
-                {c.side === 'right' && (
-                  <>
-                    <div />
-                    <div className="text-left pl-3">
-                      <div className="font-bold text-[13px]">{c.name}</div>
-                      <div className="text-[10px] text-white/40 font-medium">{c.dist}</div>
-                    </div>
-                  </>
-                )}
-
-                {/* pin in center */}
-                {c.highlight ? (
-                  <div className="absolute left-1/2 -translate-x-1/2 -translate-y-[2px]">
-                    <motion.div
-                      animate={{ scale: [1, 1.15, 1] }}
-                      transition={{ duration: 2, repeat: Infinity }}
-                      className="relative"
-                    >
-                      <div className="absolute inset-0 -m-3 rounded-full bg-amber-500/30 blur-md" />
-                      <div className="relative px-3 py-1.5 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-[#05070D] text-[10px] font-black tracking-widest shadow-lg shadow-amber-500/40">
-                        ★ KOSI ★
-                      </div>
-                      <div className="text-center mt-1 text-[9px] font-black text-amber-400 tracking-wider">
-                        SHREE KUNJ BIHARI ENCLAVE
-                      </div>
-                    </motion.div>
-                  </div>
-                ) : (
-                  <div
-                    className="absolute left-1/2 -translate-x-1/2 w-2 h-2 rounded-full bg-amber-400/40 border border-amber-400/60"
-                    style={{ top: `${64 + i * 48}px` }}
-                  />
-                )}
+                <div className="relative">
+                  <div className="absolute inset-0 -m-4 rounded-full bg-amber-500/40 blur-lg animate-pulse" />
+                  <div className="relative w-4 h-7 rounded-md bg-gradient-to-b from-amber-300 to-amber-600 shadow-lg shadow-amber-500/50" />
+                </div>
               </motion.div>
-            ))}
+
+              {/* Corridor cities */}
+              <div className="relative h-full flex flex-col justify-around py-4">
+                {CORRIDOR.map((c, i) => (
+                  <div key={c.name} className="relative grid grid-cols-2 items-center gap-2 h-8">
+                    {c.side === 'left' && (
+                      <>
+                        <motion.div
+                          initial={{ opacity: 0, x: -20 }} whileInView={{ opacity: 1, x: 0 }} viewport={{ once: true, margin: '-10%' }}
+                          transition={{ delay: i * 0.05 }}
+                          className="text-right pr-4"
+                        >
+                          <div className="font-bold text-[12px] text-white">{c.name}</div>
+                          <div className="text-[9px] text-white/40 font-medium">{c.dist} · {c.drive}</div>
+                        </motion.div>
+                        <div />
+                      </>
+                    )}
+                    {c.side === 'right' && (
+                      <>
+                        <div />
+                        <motion.div
+                          initial={{ opacity: 0, x: 20 }} whileInView={{ opacity: 1, x: 0 }} viewport={{ once: true, margin: '-10%' }}
+                          transition={{ delay: i * 0.05 }}
+                          className="text-left pl-4"
+                        >
+                          <div className="font-bold text-[12px] text-white">{c.name}</div>
+                          <div className="text-[9px] text-white/40 font-medium">{c.dist} · {c.drive}</div>
+                        </motion.div>
+                      </>
+                    )}
+                    {c.side === 'pin' && (
+                      <div className="col-span-2 flex items-center justify-center">
+                        <motion.div
+                          initial={{ scale: 0, opacity: 0 }}
+                          whileInView={{ scale: 1, opacity: 1 }}
+                          viewport={{ once: true }}
+                          transition={{ type: 'spring', damping: 12, delay: 0.2 }}
+                          className="relative"
+                        >
+                          <div className="absolute inset-0 -m-6 rounded-full"
+                               style={{ animation: 'pulseRing 1.6s infinite ease-out', background: 'radial-gradient(circle, rgba(252,211,77,0.6), transparent 70%)' }} />
+                          <div className="absolute inset-0 -m-3 rounded-full"
+                               style={{ animation: 'pulseRing 1.6s 0.4s infinite ease-out', background: 'radial-gradient(circle, rgba(252,211,77,0.7), transparent 70%)' }} />
+                          <div className="relative px-4 py-2 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-[#030509] text-[10px] font-black tracking-widest shadow-2xl shadow-amber-500/60">
+                            ★ KOSI ★
+                          </div>
+                        </motion.div>
+                      </div>
+                    )}
+
+                    {/* milestone dot */}
+                    {!c.highlight && (
+                      <div className="absolute left-1/2 -translate-x-1/2 w-2 h-2 rounded-full bg-amber-400/50 border border-amber-400/70" />
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <p className="text-center text-[10px] text-white/40 mt-4 font-medium tracking-wider">
+              SHREE KUNJ BIHARI ENCLAVE · KOSI, MATHURA
+            </p>
           </div>
         </div>
-      </Section>
+      </section>
 
-      {/* ════════ SATELLITE MAP (Google Earth feel) ════════ */}
-      <Section className="px-5 pt-12 pb-10 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">Live Satellite View</p>
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* SATELLITE MAP — cinematic flyover                                    */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section ref={mapRef} className="px-5 pt-12 pb-12 max-w-md mx-auto" style={{ perspective: 1400 }}>
+        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">Live Satellite View</p>
         <h2 className="text-3xl font-black leading-tight mb-2">
-          See it from <span className="text-amber-400">above</span>
+          See it from <span className="gold-text">above</span>
         </h2>
         <p className="text-white/60 text-[14px] leading-relaxed mb-6">
-          The land, the highway, the railway, the temples — all in one frame.
+          The land, the highway, the railway — all in one frame.
         </p>
 
-        <div className="relative rounded-3xl overflow-hidden border border-white/15 bg-[#0A0F1C]">
-          {/* Map type toggle */}
-          <div className="absolute top-3 left-3 z-10 flex gap-1 p-1 rounded-full bg-black/60 backdrop-blur-md border border-white/10">
+        <motion.div
+          style={{ scale: mapScale, rotateZ: mapRotZ, transformStyle: 'preserve-3d' }}
+          className="relative rounded-3xl overflow-hidden border border-white/20 bg-[#0A0F1C] shadow-2xl shadow-amber-500/10"
+        >
+          {/* Type toggle */}
+          <div className="absolute top-3 left-3 z-10 flex gap-1 p-1 rounded-full bg-black/70 backdrop-blur-md border border-white/15">
             <button
               onClick={() => setMapType('satellite')}
               className={`px-3 py-1.5 rounded-full text-[10px] font-bold tracking-wide flex items-center gap-1 transition ${
-                mapType === 'satellite' ? 'bg-amber-400 text-[#05070D]' : 'text-white/70'
+                mapType === 'satellite' ? 'bg-amber-400 text-[#030509] shadow-md' : 'text-white/70'
               }`}
             >
               <Mountain className="w-3 h-3" /> SATELLITE
@@ -263,17 +515,26 @@ const KunjBihariLanding = () => {
             <button
               onClick={() => setMapType('hybrid')}
               className={`px-3 py-1.5 rounded-full text-[10px] font-bold tracking-wide flex items-center gap-1 transition ${
-                mapType === 'hybrid' ? 'bg-amber-400 text-[#05070D]' : 'text-white/70'
+                mapType === 'hybrid' ? 'bg-amber-400 text-[#030509] shadow-md' : 'text-white/70'
               }`}
             >
               <Layers className="w-3 h-3" /> LABELS
             </button>
           </div>
 
-          {/* Coordinates badge */}
-          <div className="absolute top-3 right-3 z-10 px-2.5 py-1.5 rounded-full bg-black/60 backdrop-blur-md border border-white/10 flex items-center gap-1.5">
+          {/* Coordinates */}
+          <div className="absolute top-3 right-3 z-10 px-2.5 py-1.5 rounded-full bg-black/70 backdrop-blur-md border border-emerald-400/30 flex items-center gap-1.5">
             <div className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
             <span className="text-[9px] font-mono font-bold text-emerald-300 tracking-wider">27.79°N 77.44°E</span>
+          </div>
+
+          {/* Animated crosshair overlay */}
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 pointer-events-none">
+            <div className="relative w-16 h-16">
+              <div className="absolute inset-0 rounded-full border border-amber-400/60" style={{ animation: 'pulseRing 2s infinite ease-out' }} />
+              <div className="absolute inset-0 m-3 rounded-full border border-amber-400/80" style={{ animation: 'pulseRing 2s 0.6s infinite ease-out' }} />
+              <div className="absolute inset-0 m-7 rounded-full bg-amber-400 shadow-lg shadow-amber-500/80" />
+            </div>
           </div>
 
           <iframe
@@ -281,13 +542,12 @@ const KunjBihariLanding = () => {
             src={mapSrc}
             title="Shree Kunj Bihari Enclave Location"
             className="w-full aspect-square block"
-            style={{ border: 0, filter: 'contrast(1.05) saturate(1.05)' }}
+            style={{ border: 0, filter: 'contrast(1.08) saturate(1.15) brightness(1.05)' }}
             loading="lazy"
             referrerPolicy="no-referrer-when-downgrade"
           />
 
-          {/* Bottom info bar */}
-          <div className="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-[#05070D] via-[#05070D]/90 to-transparent">
+          <div className="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-[#030509] via-[#030509]/95 to-transparent">
             <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2">
                 <Compass className="w-4 h-4 text-amber-400" />
@@ -304,32 +564,35 @@ const KunjBihariLanding = () => {
               </a>
             </div>
           </div>
-        </div>
+        </motion.div>
 
-        <p className="text-center text-[11px] text-white/40 mt-3">
-          Pinch to zoom · Satellite imagery © Google
-        </p>
-      </Section>
+        <p className="text-center text-[10px] text-white/40 mt-3 tracking-wider">PINCH TO ZOOM · IMAGERY © GOOGLE</p>
+      </section>
 
-      {/* ════════ THE OPPORTUNITY ════════ */}
-      <Section className="px-5 pt-16 pb-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">The Opportunity</p>
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* OPPORTUNITY (4 cards)                                                 */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="px-5 pt-16 pb-12 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">The Opportunity</p>
         <h2 className="text-3xl font-black leading-tight mb-5">
-          Where divinity meets <span className="text-amber-400">growth</span>
+          Where divinity meets <span className="gold-text">growth</span>
         </h2>
 
-        <div className="space-y-3">
+        <div className="space-y-3" style={{ perspective: 1200 }}>
           {[
-            { icon: '🛣️', title: 'Highway-front access', desc: 'NH-2 expressway in 5 minutes — Delhi reachable in 90 minutes.' },
-            { icon: '🏭', title: 'Industrial powerhouse', desc: 'Plants of Maruti Suzuki, Reliance, Bharat Forge, Havells & 5+ MNCs nearby.' },
-            { icon: '🛕', title: 'Spiritual gravity', desc: 'Mathura, Vrindavan, Govardhan & Shani Dev Mandir — Braj Bhoomi heritage.' },
-            { icon: '📈', title: 'Appreciation corridor', desc: 'NH-2 land prices have grown ~22% YoY in this belt.' },
+            { icon: '🛣️', title: 'Highway-front access',  desc: 'NH-2 expressway in 5 minutes — Delhi reachable in 90 minutes.' },
+            { icon: '🏭', title: 'Industrial powerhouse',  desc: 'Plants of Maruti Suzuki, Reliance, Bharat Forge, Havells & 5+ MNCs nearby.' },
+            { icon: '🛕', title: 'Spiritual gravity',      desc: 'Mathura, Vrindavan, Govardhan & Shani Dev Mandir — the heart of Braj Bhoomi.' },
+            { icon: '📈', title: 'Appreciation corridor',  desc: 'NH-2 land prices have grown ~22% YoY in this belt.' },
           ].map((b, i) => (
             <motion.div
               key={b.title}
-              initial={{ opacity: 0, x: -20 }} whileInView={{ opacity: 1, x: 0 }} viewport={{ once: true }}
-              transition={{ delay: i * 0.07 }}
-              className="flex gap-4 p-4 rounded-2xl bg-white/[0.03] border border-white/10"
+              initial={{ opacity: 0, x: -20, rotateY: -8 }}
+              whileInView={{ opacity: 1, x: 0, rotateY: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.08 }}
+              className="flex gap-4 p-4 rounded-2xl bg-gradient-to-br from-white/[0.05] to-transparent border border-white/10"
+              style={{ transformStyle: 'preserve-3d' }}
             >
               <div className="text-3xl flex-shrink-0">{b.icon}</div>
               <div>
@@ -339,12 +602,14 @@ const KunjBihariLanding = () => {
             </motion.div>
           ))}
         </div>
-      </Section>
+      </section>
 
-      {/* ════════ LANDMARKS ════════ */}
-      <Section className="px-5 py-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">Around You</p>
-        <h2 className="text-3xl font-black mb-6">Every landmark, <span className="text-amber-400">minutes away</span></h2>
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* LANDMARKS                                                            */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="px-5 py-12 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">Around You</p>
+        <h2 className="text-3xl font-black mb-6">Every landmark, <span className="gold-text">minutes away</span></h2>
 
         <div className="space-y-2.5">
           {LANDMARKS.map((l, i) => (
@@ -352,7 +617,7 @@ const KunjBihariLanding = () => {
               key={l.name}
               initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: true }}
               transition={{ delay: i * 0.05 }}
-              className="flex items-center gap-4 p-3.5 rounded-xl bg-gradient-to-r from-white/[0.04] to-transparent border border-white/[0.08]"
+              className="flex items-center gap-4 p-3.5 rounded-xl bg-gradient-to-r from-white/[0.05] to-transparent border border-white/[0.08]"
             >
               <div className="w-11 h-11 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center text-xl flex-shrink-0">
                 {l.emoji}
@@ -367,102 +632,134 @@ const KunjBihariLanding = () => {
             </motion.div>
           ))}
         </div>
-      </Section>
+      </section>
 
-      {/* ════════ CONNECTIVITY ════════ */}
-      <Section className="px-5 py-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">Reach Anywhere</p>
-        <h2 className="text-3xl font-black mb-6">Connectivity that <span className="text-amber-400">pays</span></h2>
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* INDUSTRIAL BRANDS — infinite marquee                                 */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="py-16 overflow-hidden">
+        <div className="px-5 max-w-md mx-auto mb-6">
+          <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">Industrial Neighbors</p>
+          <h2 className="text-3xl font-black">
+            The brands that <span className="gold-text">moved here first</span>
+          </h2>
+          <p className="text-white/60 text-[13px] leading-relaxed mt-3">
+            When global manufacturers anchor a corridor, land value follows.
+          </p>
+        </div>
 
-        <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-amber-500/5 to-transparent p-1">
-          <div className="rounded-[1.4rem] bg-[#0A0F1C]/60 backdrop-blur p-5">
-            {CONNECTIVITY.map((c, i) => (
-              <div key={c.place} className={`flex items-center justify-between py-3 ${i < CONNECTIVITY.length - 1 ? 'border-b border-white/5' : ''}`}>
-                <div className="flex items-center gap-3">
-                  <Clock className="w-4 h-4 text-amber-400/70" />
-                  <span className="font-semibold text-[15px]">{c.place}</span>
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 w-12 bg-gradient-to-r from-[#030509] to-transparent z-10 pointer-events-none" />
+          <div className="absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-[#030509] to-transparent z-10 pointer-events-none" />
+          <div className="flex gap-3 overflow-hidden" style={{ width: '100%' }}>
+            <div className="flex gap-3 shrink-0" style={{ animation: 'marquee 28s linear infinite' }}>
+              {[...BRANDS, ...BRANDS].map((b, i) => (
+                <div
+                  key={i}
+                  className="shrink-0 min-w-[120px] h-16 rounded-2xl bg-gradient-to-br from-white/[0.07] to-white/[0.02] border border-white/10 flex items-center justify-center px-4"
+                >
+                  <span className="text-[12px] font-bold text-white/90 text-center">{b}</span>
                 </div>
-                <div className="text-right">
-                  <div className="font-black text-white">{c.time}</div>
-                  <div className="text-[10px] text-white/40 font-medium">{c.km}</div>
-                </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
         </div>
-      </Section>
+      </section>
 
-      {/* ════════ INDUSTRIAL NEIGHBORS ════════ */}
-      <Section className="px-5 py-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">Your Industrial Neighbors</p>
-        <h2 className="text-3xl font-black mb-3">The companies that <span className="text-amber-400">moved here first</span></h2>
-        <p className="text-white/60 text-[14px] leading-relaxed mb-6">
-          When global manufacturers anchor a corridor, land value follows. These plants are already running, adjacent to your plot.
-        </p>
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* PRICING — 3D tilted card                                             */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="px-5 py-12 max-w-md mx-auto" style={{ perspective: 1200 }}>
+        <Tilt3D intensity={6}>
+          <div className="relative rounded-[2rem] overflow-hidden shadow-2xl shadow-amber-500/30">
+            <div className="absolute inset-0 bg-gradient-to-br from-amber-400 via-orange-500 to-amber-600" />
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.25),transparent_55%)]" />
+            <span
+              className="absolute -inset-px opacity-50 pointer-events-none"
+              style={{
+                background: 'linear-gradient(120deg, transparent 30%, rgba(255,255,255,0.4) 50%, transparent 70%)',
+                backgroundSize: '200% 100%',
+                animation: 'shine 4s infinite',
+              }}
+            />
+            <div className="relative p-7 text-[#030509]">
+              <p className="text-[11px] font-bold tracking-[0.25em] uppercase opacity-70 mb-2">Plots Starting From</p>
+              <div className="flex items-baseline gap-2 mb-1">
+                <span className="text-xs font-black opacity-80">₹</span>
+                <span className="text-6xl font-black tracking-tight">
+                  <Counter to={7525} />
+                </span>
+              </div>
+              <p className="text-sm font-bold opacity-80 mb-5">per square yard</p>
 
-        <div className="grid grid-cols-3 gap-2.5">
-          {BRANDS.map((b, i) => (
+              <div className="grid grid-cols-3 gap-2 mb-2">
+                {[
+                  { v: 10, label: 'Booking' },
+                  { v: 35, label: 'Registry' },
+                  { v: 60, label: 'Mo EMI' },
+                ].map(x => (
+                  <div key={x.label} className="text-center py-3 bg-black/15 rounded-xl">
+                    <div className="text-xl font-black"><Counter to={x.v} />{x.label === 'Booking' || x.label === 'Registry' ? '%' : ''}</div>
+                    <div className="text-[10px] font-bold uppercase opacity-70">{x.label}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </Tilt3D>
+
+        {/* Plot size grid */}
+        <div className="grid grid-cols-2 gap-3 mt-6">
+          {PLOTS.map((p, i) => (
             <motion.div
-              key={b}
-              initial={{ opacity: 0, scale: 0.9 }} whileInView={{ opacity: 1, scale: 1 }} viewport={{ once: true }}
-              transition={{ delay: i * 0.04 }}
-              className="aspect-square rounded-2xl bg-gradient-to-br from-white/[0.06] to-white/[0.02] border border-white/10 flex items-center justify-center p-3 text-center"
+              key={p.size}
+              initial={{ opacity: 0, y: 20, rotateX: -10 }}
+              whileInView={{ opacity: 1, y: 0, rotateX: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.06 }}
+              className={`relative p-4 rounded-2xl border ${p.highlight ? 'bg-gradient-to-br from-amber-500/10 to-amber-500/0 border-amber-400/40' : 'bg-white/[0.03] border-white/10'}`}
+              style={{ transformStyle: 'preserve-3d' }}
             >
-              <span className="text-[11px] font-bold text-white/90 leading-tight">{b}</span>
+              {p.highlight && (
+                <div className="absolute -top-2 right-3 text-[8px] font-black px-2 py-0.5 rounded-full bg-amber-400 text-[#030509] tracking-wider">
+                  POPULAR
+                </div>
+              )}
+              <div className="text-[10px] text-white/40 font-bold uppercase tracking-wider mb-1">Plot</div>
+              <div className="text-2xl font-black mb-3">{p.size} <span className="text-[11px] text-white/50 font-medium">sq yd</span></div>
+              <div className="flex items-baseline gap-1 mb-1">
+                <span className="text-[10px] text-white/40">Total</span>
+                <span className="text-sm font-bold text-white">₹{(p.total/100000).toFixed(2)}L</span>
+              </div>
+              <div className="flex items-baseline gap-1">
+                <span className="text-[10px] text-amber-400/80">EMI</span>
+                <span className="text-sm font-bold text-amber-400">₹{p.emi.toLocaleString('en-IN')}</span>
+                <span className="text-[10px] text-amber-400/60">/mo</span>
+              </div>
             </motion.div>
           ))}
         </div>
-      </Section>
+      </section>
 
-      {/* ════════ PRICING TEASER (no CTA — info only) ════════ */}
-      <Section className="px-5 py-12 max-w-md mx-auto">
-        <div className="relative rounded-[2rem] overflow-hidden">
-          <div className="absolute inset-0 bg-gradient-to-br from-amber-500 via-orange-500 to-amber-600" />
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.2),transparent_50%)]" />
-          <div className="relative p-7 text-[#05070D]">
-            <p className="text-[11px] font-bold tracking-[0.2em] uppercase opacity-70 mb-2">Plots Starting From</p>
-            <div className="flex items-baseline gap-2 mb-1">
-              <span className="text-xs font-black opacity-80">₹</span>
-              <span className="text-6xl font-black tracking-tight">7,525</span>
-            </div>
-            <p className="text-sm font-bold opacity-80 mb-5">per square yard</p>
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* INFRASTRUCTURE                                                       */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="px-5 py-12 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">Inside the Gates</p>
+        <h2 className="text-3xl font-black mb-6">Built like a <span className="gold-text">forever home</span></h2>
 
-            <div className="grid grid-cols-3 gap-2 mb-2">
-              <div className="text-center py-3 bg-black/10 rounded-xl">
-                <div className="text-xl font-black">10%</div>
-                <div className="text-[10px] font-bold uppercase opacity-70">Booking</div>
-              </div>
-              <div className="text-center py-3 bg-black/10 rounded-xl">
-                <div className="text-xl font-black">35%</div>
-                <div className="text-[10px] font-bold uppercase opacity-70">Registry</div>
-              </div>
-              <div className="text-center py-3 bg-black/10 rounded-xl">
-                <div className="text-xl font-black">60</div>
-                <div className="text-[10px] font-bold uppercase opacity-70">Mo EMI</div>
-              </div>
-            </div>
-
-            <p className="text-center text-[11px] font-bold opacity-70 mt-4">
-              Plot sizes: 50 · 55 · 60 · 80 · 100 · 120 · 150 · 200 · 250 sq yd
-            </p>
-          </div>
-        </div>
-      </Section>
-
-      {/* ════════ INFRASTRUCTURE ════════ */}
-      <Section className="px-5 py-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3">Inside the Gates</p>
-        <h2 className="text-3xl font-black mb-6">Built like a <span className="text-amber-400">forever home</span></h2>
-
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 gap-3" style={{ perspective: 800 }}>
           {INFRA.map((f, i) => (
             <motion.div
               key={f.title}
-              initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }}
+              initial={{ opacity: 0, y: 30, rotateY: -10 }}
+              whileInView={{ opacity: 1, y: 0, rotateY: 0 }}
+              viewport={{ once: true }}
               transition={{ delay: i * 0.06 }}
-              className="p-4 rounded-2xl bg-white/[0.03] border border-white/10"
+              className="p-4 rounded-2xl bg-white/[0.04] border border-white/10"
+              style={{ transformStyle: 'preserve-3d' }}
             >
-              <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-3" style={{ background: `${f.color}20`, border: `1px solid ${f.color}40` }}>
+              <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-3" style={{ background: `${f.color}25`, border: `1px solid ${f.color}50` }}>
                 <f.icon className="w-5 h-5" style={{ color: f.color }} />
               </div>
               <h3 className="font-bold text-sm mb-1">{f.title}</h3>
@@ -470,31 +767,42 @@ const KunjBihariLanding = () => {
             </motion.div>
           ))}
         </div>
-      </Section>
+      </section>
 
-      {/* ════════ TRUST BADGES ════════ */}
-      <Section className="px-5 py-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.2em] uppercase mb-3 text-center">Investor Assurance</p>
-        <h2 className="text-3xl font-black text-center mb-6">Promises we <span className="text-amber-400">put in writing</span></h2>
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* TRUST BADGES                                                         */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="px-5 py-12 max-w-md mx-auto">
+        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3 text-center">Investor Assurance</p>
+        <h2 className="text-3xl font-black text-center mb-6">Promises we <span className="gold-text">put in writing</span></h2>
 
         <div className="grid grid-cols-2 gap-3">
-          {TRUST.map((t) => (
-            <div key={t.label} className="p-5 rounded-2xl bg-gradient-to-br from-white/[0.06] to-white/[0.02] border border-amber-500/20 text-center">
+          {TRUST.map((t, i) => (
+            <motion.div
+              key={t.label}
+              initial={{ opacity: 0, scale: 0.85 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.07, type: 'spring' }}
+              className="p-5 rounded-2xl bg-gradient-to-br from-amber-500/10 to-white/[0.02] border border-amber-500/30 text-center"
+            >
               <t.icon className="w-7 h-7 mx-auto text-amber-400 mb-2" />
               <div className="font-bold text-sm">{t.label}</div>
-            </div>
+            </motion.div>
           ))}
         </div>
-      </Section>
+      </section>
 
-      {/* ════════ SECURITY ════════ */}
-      <Section className="px-5 py-12 max-w-md mx-auto">
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* SECURITY                                                             */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="px-5 py-12 max-w-md mx-auto">
         <div className="relative rounded-[2rem] overflow-hidden border border-white/10 bg-gradient-to-br from-blue-900/30 via-[#0A0F1C] to-[#0A0F1C] p-7">
           <Shield className="w-12 h-12 text-blue-400 mb-4" />
           <h2 className="text-2xl font-black mb-3">A community you can <span className="text-blue-400">leave at the gate</span></h2>
           <p className="text-white/70 text-[14px] leading-relaxed mb-5">
-            Closed boundary. Single entry. 24×7 trained guards. CCTV at gate and access points. Only authorized vehicles inside.
-            Your family's peace, your plot's protection — engineered in.
+            Closed boundary. Single entry. 24×7 trained guards. CCTV at gate and access points.
+            Only authorized vehicles inside.
           </p>
           <div className="grid grid-cols-2 gap-3 text-[12px]">
             {['24×7 guards', 'CCTV gate', 'Closed boundary', 'Authorized entry only'].map(b => (
@@ -505,31 +813,69 @@ const KunjBihariLanding = () => {
             ))}
           </div>
         </div>
-      </Section>
+      </section>
 
-      {/* ════════ FINAL — no CTAs, just legacy framing ════════ */}
-      <Section className="px-5 py-20 max-w-md mx-auto text-center">
-        <Star className="w-10 h-10 text-amber-400 mx-auto mb-4 fill-amber-400" />
-        <h2 className="text-4xl font-black mb-3 leading-tight">
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* FINALE — Golden seal                                                  */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="px-5 py-24 max-w-md mx-auto text-center relative">
+        <Particles count={20} />
+
+        <motion.div
+          initial={{ scale: 0, rotate: -180, opacity: 0 }}
+          whileInView={{ scale: 1, rotate: 0, opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ type: 'spring', damping: 14, duration: 1.4 }}
+          className="relative inline-block mb-8"
+        >
+          <div className="relative w-28 h-28 rounded-full bg-gradient-to-br from-amber-300 via-amber-500 to-orange-600 shadow-2xl shadow-amber-500/40 flex items-center justify-center">
+            <div className="absolute inset-2 rounded-full border-2 border-[#030509]/30" />
+            <Gem className="w-12 h-12 text-[#030509]" />
+          </div>
+          <div className="absolute inset-0 -m-6 rounded-full"
+               style={{ animation: 'pulseRing 2.5s infinite ease-out', background: 'radial-gradient(circle, rgba(252,211,77,0.4), transparent 70%)' }} />
+        </motion.div>
+
+        <h2 className="text-[44px] font-black leading-[0.95] mb-4 relative z-10">
           Your plot.<br/>
-          <span className="text-amber-400">Your legacy.</span>
+          <span className="gold-text">Your legacy.</span>
         </h2>
-        <p className="text-white/70 text-[15px] leading-relaxed mb-8">
-          Inventory on the front rows of NH-2 is finite. Speak to the advisor who shared this page with you to lock the plot that fits your goal.
+        <p className="text-white/70 text-[15px] leading-relaxed mb-10 relative z-10">
+          Inventory on the front rows of NH-2 is finite.
+          Speak to the advisor who shared this page with you
+          to lock the plot that fits your goal.
         </p>
 
-        <div className="inline-flex items-center gap-2 px-4 py-3 rounded-full bg-white/[0.05] border border-amber-400/30">
-          <Sparkles className="w-4 h-4 text-amber-400" />
-          <span className="text-[13px] font-semibold text-amber-200">
-            Continue this conversation with your advisor
+        <div className="inline-flex items-center gap-2 px-5 py-3.5 rounded-full bg-gradient-to-r from-amber-500/20 via-amber-400/30 to-amber-500/20 border border-amber-400/50 backdrop-blur-md relative z-10">
+          <Sparkles className="w-4 h-4 text-amber-300" />
+          <span className="text-[13px] font-bold gold-text">
+            Continue with your advisor
           </span>
         </div>
 
-        <p className="mt-12 text-[11px] text-white/40 leading-relaxed">
-          Shree Kunj Bihari Enclave · Kosi Kalan · Mathura, UP<br/>
-          A <span className="text-amber-400 font-bold">Fanbe Group</span> Project
+        <p className="mt-14 text-[10px] text-white/40 leading-relaxed tracking-wider relative z-10">
+          SHREE KUNJ BIHARI ENCLAVE · KOSI KALAN · MATHURA, UP<br/>
+          A <span className="gold-text font-bold">Fanbe Group</span> Development
         </p>
-      </Section>
+      </section>
+
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* Floating advisor chip after scroll                                   */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {showAdvisorChip && (
+        <motion.div
+          initial={{ y: 80, opacity: 0 }} animate={{ y: 0, opacity: 1 }}
+          transition={{ type: 'spring', damping: 18 }}
+          className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50"
+        >
+          <button
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-[#030509] text-[12px] font-black tracking-wider shadow-2xl shadow-amber-500/40 active:scale-95 transition"
+          >
+            <ChevronUp className="w-4 h-4" /> BACK TO TOP
+          </button>
+        </motion.div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

A complete overhaul of `/kunj-bihari` to feel like the flagship ₹100 Cr development it is. Cinematic, 3D, particle-rich, scrollytelling-driven.

### Hero
- **Letter-by-letter title reveal** with rotateX flip-in (each character flips up from below with spring physics)
- **"A ₹100 CRORE DEVELOPMENT"** crown badge with animated gold shimmer
- **40 gold particles** drifting in the background (12s loops, varied seeds)
- **Parallax background**: scroll-driven Y translate + scale + opacity transform
- **Animated gold gradient text** — `background-position` shine on a 5s loop

### Stats
- **3D flip-in** from `rotateY: -90, z: -100` to flat (perspective: 1000)

### New Numbers Section
- **3 animated counters** with easeOutQuart easing, triggered by in-view:
  - ₹100 Cr (Project Worth)
  - +22% (NH-2 Growth/yr)
  - 9+ (Plot Sizes)

### NH-2 Sticky Scrollytelling Journey
- **220vh tall section** that pins for a full screen height while you scroll
- **Glowing amber "car"** travels DOWN the highway as `scrollYProgress` goes 0 → 1 (uses `useScroll` + `useTransform` to bind position to scroll)
- **KOSI pin** has dual ring pulse animations + amber gradient halo
- Cities materialize from their highway sides as they enter view

### Satellite Map (cinematic flyover)
- Card itself **scales and rotates on Z** as you scroll past (driven by `useScroll` + `useTransform`)
- **Triple-ring pulsing crosshair** overlay marks the exact spot
- CSS filter `contrast(1.08) saturate(1.15) brightness(1.05)` for that Google-Earth-cinema look
- Toggle between Satellite/Labels stays
- Deep link to `maps.app.goo.gl/AdZxBk4tLRGceHAn8`

### Opportunity Cards
- `rotateY` 3D entrance with preserved-3d perspective

### NEW: Industrial Brand Marquee
- Replaced the static 3×3 grid with a **continuous infinite horizontal marquee** (CSS keyframe animation, 28s loop)
- Edge fade gradients crop the marquee cinematically

### Pricing (3D tilt)
- Wrapped in custom **`Tilt3D` component** — card tilts on touch/mouse with `useMotionValue` + `useSpring` physics
- Animated counters for ₹7,525, 10%, 35%, 60mo
- Animated **shine sweep** diagonal overlay
- New plot-size grid below: 6 cards (50, 80, 100, 150, 200, 250 sq yd) with 100 marked **POPULAR**
- Each plot card flips up with `rotateX` entrance

### Trust + Infrastructure + Security
- All cards get 3D `rotateY` entrance with `perspective`

### Finale (Golden Seal)
- **Spring-launched golden gem** that rotates 180° → 0° on entrance
- Pulsing radial glow halo
- Reusable Particle field
- "Your plot. Your legacy." with gold-shine gradient

### Back-to-Top Chip
- Appears after 500px scroll, gold gradient pill, replaces the old fixed CTA bar

### Utilities added (in-file)
- `Particles` component (seeded for stable layouts)
- `Counter` (requestAnimationFrame + useInView, easeOutQuart)
- `Tilt3D` (touch + mouse spring tilt wrapper)
- CSS keyframes: `marquee`, `pulseRing`, `shine`
- `.gold-text` class with animated background-position shine

## Lead protection (preserved)
No phone, no WhatsApp, no contact form. The page ends with "Continue with your advisor" — investors must go back to the telecaller who shared the link.

## Test plan
- [ ] Open `/kunj-bihari` on a phone — title reveals letter-by-letter, particles drift in background
- [ ] Crown badge shimmers and pulses
- [ ] Scroll → numbers section counts up animatedly
- [ ] Scroll through NH-2 corridor — car visibly travels down the highway as you scroll
- [ ] Satellite map subtly tilts and zooms as you scroll past it
- [ ] Brand marquee scrolls continuously
- [ ] Pricing card tilts in 3D when you touch/move on it
- [ ] Plot cards flip up on entry; "100 sq yd" marked POPULAR
- [ ] Golden gem at finale launches with rotation
- [ ] After 500px scroll, gold "BACK TO TOP" chip floats at bottom
- [ ] No Call / WhatsApp buttons anywhere

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_