### PR TITLE
refactor(landing): investor-focused 6-section flow + real brand logos

### DIFF
--- a/src/pages/KunjBihariLanding.jsx
+++ b/src/pages/KunjBihariLanding.jsx
@@ -4,12 +4,11 @@ import { Helmet } from 'react-helmet';
 import {
   MapPin, Train, Building2, Shield, Zap, Droplet, Trees, Car,
   Sparkles, CheckCircle2, IndianRupee, Clock, Star, ArrowDown,
-  BadgeCheck, Compass, Layers, Mountain, TrendingUp, Award, Crown,
-  Gem, ChevronUp
+  BadgeCheck, Compass, Layers, Mountain, TrendingUp, Award, Gem,
+  ChevronUp, ArrowUpRight, FileCheck, Activity
 } from 'lucide-react';
 
 // ────────────────────────────────────────────────────────────────────────────
-// Configuration
 const HERO = 'https://mfgjzkaabyltscgrkhdz.supabase.co/storage/v1/object/public/project-images/projects/shree-kunj-bihari/hero.jpg';
 const LAT = 27.7910;
 const LNG = 77.4385;
@@ -18,15 +17,13 @@ const SATELLITE_EMBED = `https://maps.google.com/maps?q=${LAT},${LNG}&t=k&z=16&i
 const HYBRID_EMBED    = `https://maps.google.com/maps?q=${LAT},${LNG}&t=h&z=15&ie=UTF8&iwloc=&output=embed`;
 
 const CORRIDOR = [
-  { name: 'Delhi NCR',  dist: '110 km', side: 'left',  drive: '90 min' },
-  { name: 'Badarpur',   dist: '95 km',  side: 'left',  drive: '80 min' },
-  { name: 'Palwal',     dist: '60 km',  side: 'left',  drive: '55 min' },
-  { name: 'Hodal',      dist: '30 km',  side: 'left',  drive: '30 min' },
-  { name: 'KOSI',       dist: '0 km',   side: 'pin',   highlight: true, drive: 'HERE' },
-  { name: 'Chhata',     dist: '10 km',  side: 'right', drive: '10 min' },
-  { name: 'Akbarpur',   dist: '18 km',  side: 'right', drive: '15 min' },
-  { name: 'Vrindavan',  dist: '30 km',  side: 'right', drive: '25 min' },
-  { name: 'Mathura',    dist: '24 km',  side: 'right', drive: '20 min' },
+  { name: 'Delhi NCR',  km: '110 km', drive: '90 min', side: 'left'  },
+  { name: 'Palwal',     km: '60 km',  drive: '55 min', side: 'left'  },
+  { name: 'Hodal',      km: '30 km',  drive: '30 min', side: 'left'  },
+  { name: 'KOSI',       km: '0 km',   drive: 'HERE',   side: 'pin',   highlight: true },
+  { name: 'Chhata',     km: '10 km',  drive: '10 min', side: 'right' },
+  { name: 'Vrindavan',  km: '30 km',  drive: '25 min', side: 'right' },
+  { name: 'Mathura',    km: '24 km',  drive: '20 min', side: 'right' },
 ];
 
 const STATS = [
@@ -37,47 +34,73 @@ const STATS = [
 ];
 
 const LANDMARKS = [
-  { emoji: '🛣️', name: 'National Highway (NH-2)', dist: '5 min',  tag: 'Connectivity' },
-  { emoji: '🚆', name: 'Kosi Railway Station',     dist: '5 min',  tag: 'Transport' },
-  { emoji: '🛕', name: 'Shani Dev Mandir',         dist: '5 min',  tag: 'Spiritual' },
-  { emoji: '🛕', name: 'Jagannath Dham',           dist: 'Nearby', tag: 'Spiritual' },
-  { emoji: '🛕', name: 'Nand Baba Mandir',         dist: 'Nearby', tag: 'Spiritual' },
-  { emoji: '🏭', name: 'Industrial Area',          dist: 'Adjacent', tag: 'Employment' },
-  { emoji: '🌳', name: 'Gokul Vatika',             dist: 'Nearby', tag: 'Lifestyle' },
+  { emoji: '🛣️',  name: 'National Highway (NH-2)',  dist: '5 min',  tag: 'Connectivity' },
+  { emoji: '🚆',  name: 'Kosi Railway Station',      dist: '5 min',  tag: 'Transport' },
+  { emoji: '🛕',  name: 'Shani Dev Mandir',          dist: '5 min',  tag: 'Spiritual' },
+  { emoji: '🕉️',  name: 'Durwasha Rishi Ashram',     dist: 'Nearby', tag: 'Heritage' },
+  { emoji: '🛕',  name: 'Jagannath Dham',            dist: 'Nearby', tag: 'Spiritual' },
+  { emoji: '🛕',  name: 'Nand Baba Mandir',          dist: 'Nearby', tag: 'Spiritual' },
+  { emoji: '🏭',  name: 'Industrial Area',           dist: 'Adjacent', tag: 'Employment' },
+  { emoji: '🌳',  name: 'Gokul Vatika',              dist: 'Nearby', tag: 'Lifestyle' },
 ];
 
+const CONNECTIVITY = [
+  { place: 'Mathura',    time: '20 min', km: '24 km' },
+  { place: 'Vrindavan',  time: '25 min', km: '30 km' },
+  { place: 'Govardhan',  time: '40 min', km: '45 km' },
+  { place: 'Palwal',     time: '55 min', km: '60 km' },
+  { place: 'Delhi NCR',  time: '90 min', km: '110 km' },
+  { place: 'Agra',       time: '90 min', km: '70 km' },
+];
+
+// Industry brands with Clearbit logo URLs (publicly accessible)
 const BRANDS = [
-  'Maruti Suzuki', 'YAZAKI', 'DAIKIN', 'UFLEX', 'JK Tyre',
-  'HAVELLS', 'PARLE', 'Reliance', 'BHARAT FORGE',
-];
-
-const PLOTS = [
-  { size: 50,  total: 376250,  emi: 5644,  highlight: false },
-  { size: 80,  total: 602000,  emi: 9030,  highlight: false },
-  { size: 100, total: 752500,  emi: 11287, highlight: true  },
-  { size: 150, total: 1128750, emi: 16931, highlight: false },
-  { size: 200, total: 1505000, emi: 22575, highlight: false },
-  { size: 250, total: 1881250, emi: 28219, highlight: false },
+  { name: 'Maruti Suzuki', domain: 'marutisuzuki.com',   accent: '#E60012' },
+  { name: 'Reliance',      domain: 'ril.com',            accent: '#003366' },
+  { name: 'DAIKIN',        domain: 'daikin.com',         accent: '#E50012' },
+  { name: 'HAVELLS',       domain: 'havells.com',        accent: '#C8102E' },
+  { name: 'JK Tyre',       domain: 'jktyre.com',         accent: '#E32726' },
+  { name: 'Bharat Forge',  domain: 'bharatforge.com',    accent: '#0D4F8B' },
+  { name: 'PARLE',         domain: 'parleproducts.com',  accent: '#FCB900' },
+  { name: 'YAZAKI',        domain: 'yazaki-group.com',   accent: '#0F913F' },
+  { name: 'UFLEX',         domain: 'uflexltd.com',       accent: '#EE7800' },
 ];
 
 const INFRA = [
-  { icon: Building2, title: 'Grand Entrance',     desc: 'With dedicated guard room',         color: '#F59E0B' },
-  { icon: Car,       title: 'Wide Damar Roads',   desc: 'Blacktop roads inside colony',      color: '#0EA5E9' },
-  { icon: Zap,       title: 'Electricity Ready',  desc: 'Full power supply infrastructure',  color: '#FACC15' },
-  { icon: Droplet,   title: 'Water Supply',       desc: '24×7 dependable water',             color: '#06B6D4' },
-  { icon: Trees,     title: 'Green Environment',  desc: 'Pollution-free, planned greenery',  color: '#22C55E' },
-  { icon: Shield,    title: 'Gated Boundary',     desc: 'Closed perimeter, single entry',    color: '#6366F1' },
+  { icon: Building2, title: 'Grand Entrance',     desc: 'Dedicated guard room' },
+  { icon: Car,       title: 'Wide Damar Roads',   desc: 'Blacktop, planned' },
+  { icon: Zap,       title: 'Electricity Ready',  desc: 'Full power supply' },
+  { icon: Droplet,   title: 'Water Supply',       desc: '24×7 dependable' },
+  { icon: Trees,     title: 'Green Belt',         desc: 'Pollution-free zones' },
+  { icon: Shield,    title: 'Gated Boundary',     desc: 'Closed perimeter' },
 ];
 
 const TRUST = [
-  { icon: BadgeCheck,   label: '100% Clear Title' },
-  { icon: CheckCircle2, label: 'Immediate Mutation' },
+  { icon: FileCheck,    label: 'Immediate Registry' },
+  { icon: CheckCircle2, label: 'Mutation in Hand' },
   { icon: Shield,       label: 'No Hidden Charges' },
   { icon: IndianRupee,  label: '0% Interest EMI' },
 ];
 
+const PLOTS = [
+  { size: 250, total: 1881250, emi: 28219 },
+  { size: 200, total: 1505000, emi: 22575 },
+  { size: 150, total: 1128750, emi: 16931 },
+  { size: 120, total:  903000, emi: 13545 },
+  { size: 100, total:  752500, emi: 11287, popular: true },
+  { size:  80, total:  602000, emi: 9030  },
+  { size:  60, total:  451500, emi: 6772  },
+  { size:  50, total:  376250, emi: 5644  },
+];
+
+const APPRECIATION = [
+  { stat: '22%',  label: 'YoY land-price growth on this NH-2 belt',   icon: TrendingUp },
+  { stat: '35%',  label: 'YoY tourism rise in Braj Bhoomi (Mathura)', icon: Activity },
+  { stat: '5+',   label: 'Active MNC manufacturing plants nearby',    icon: Building2 },
+  { stat: 'NH-2', label: 'Delhi-Agra national corridor frontage',     icon: Compass },
+];
+
 // ────────────────────────────────────────────────────────────────────────────
-// Particles — gold ambient drift
 const Particles = ({ count = 30 }) => {
   const seeds = React.useMemo(
     () => Array.from({ length: count }, (_, i) => ({
@@ -88,20 +111,16 @@ const Particles = ({ count = 30 }) => {
       o: 0.15 + Math.random() * 0.45,
       delay: Math.random() * 8,
       id: i,
-    })),
-    [count]
+    })), [count]
   );
   return (
     <div className="absolute inset-0 pointer-events-none overflow-hidden">
-      {seeds.map((p) => (
+      {seeds.map(p => (
         <motion.div
           key={p.id}
           className="absolute rounded-full"
           style={{
-            left: `${p.x}%`,
-            top: `${p.y}%`,
-            width: p.s,
-            height: p.s,
+            left: `${p.x}%`, top: `${p.y}%`, width: p.s, height: p.s,
             background: 'radial-gradient(circle, rgba(252,211,77,0.9), rgba(252,211,77,0) 70%)',
             opacity: p.o,
           }}
@@ -113,8 +132,7 @@ const Particles = ({ count = 30 }) => {
   );
 };
 
-// Animated number counter
-const Counter = ({ to, suffix = '', duration = 1.6 }) => {
+const Counter = ({ to, suffix = '', duration = 1.4 }) => {
   const ref = useRef(null);
   const inView = useInView(ref, { once: true, margin: '-50px' });
   const [val, setVal] = useState(0);
@@ -124,22 +142,17 @@ const Counter = ({ to, suffix = '', duration = 1.6 }) => {
     let raf;
     const tick = (t) => {
       const p = Math.min(1, (t - start) / (duration * 1000));
-      const eased = 1 - Math.pow(1 - p, 4); // easeOutQuart
+      const eased = 1 - Math.pow(1 - p, 4);
       setVal(Math.round(to * eased));
       if (p < 1) raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
   }, [inView, to, duration]);
-  return (
-    <span ref={ref}>
-      {val.toLocaleString('en-IN')}{suffix}
-    </span>
-  );
+  return <span ref={ref}>{val.toLocaleString('en-IN')}{suffix}</span>;
 };
 
-// 3D tilt wrapper (touch-aware)
-const Tilt3D = ({ children, intensity = 8, className = '' }) => {
+const Tilt3D = ({ children, intensity = 6, className = '' }) => {
   const rx = useMotionValue(0);
   const ry = useMotionValue(0);
   const sx = useSpring(rx, { stiffness: 220, damping: 18 });
@@ -155,60 +168,46 @@ const Tilt3D = ({ children, intensity = 8, className = '' }) => {
   return (
     <motion.div
       className={className}
-      onMouseMove={handle}
-      onTouchMove={handle}
-      onMouseLeave={reset}
-      onTouchEnd={reset}
-      style={{
-        rotateX: sx, rotateY: sy,
-        transformStyle: 'preserve-3d', transformPerspective: 1000,
-      }}
+      onMouseMove={handle} onTouchMove={handle}
+      onMouseLeave={reset} onTouchEnd={reset}
+      style={{ rotateX: sx, rotateY: sy, transformStyle: 'preserve-3d', transformPerspective: 1000 }}
     >
       {children}
     </motion.div>
   );
 };
 
+const SectionLabel = ({ children }) => (
+  <p className="text-amber-400 text-[11px] font-bold tracking-[0.3em] uppercase mb-3">{children}</p>
+);
+
 // ────────────────────────────────────────────────────────────────────────────
 
 const KunjBihariLanding = () => {
-  // Hero parallax
   const heroRef = useRef(null);
   const { scrollYProgress: heroProg } = useScroll({ target: heroRef, offset: ['start start', 'end start'] });
-  const heroBgY    = useTransform(heroProg, [0, 1], [0, 180]);
-  const heroBgScale = useTransform(heroProg, [0, 1], [1.05, 1.25]);
-  const heroOpac    = useTransform(heroProg, [0, 0.6, 1], [1, 0.6, 0]);
-  const heroTitleY  = useTransform(heroProg, [0, 1], [0, -60]);
-
-  // Sticky NH-2 journey
-  const journeyRef = useRef(null);
-  const { scrollYProgress: jProg } = useScroll({ target: journeyRef, offset: ['start start', 'end end'] });
-  const carY = useTransform(jProg, [0, 1], ['0%', '100%']);
-
-  // Satellite section flyover effect
-  const mapRef = useRef(null);
-  const { scrollYProgress: mProg } = useScroll({ target: mapRef, offset: ['start end', 'end start'] });
-  const mapScale = useTransform(mProg, [0, 0.5, 1], [0.85, 1, 1.05]);
-  const mapRotZ  = useTransform(mProg, [0, 1], [-2, 2]);
+  const heroBgY     = useTransform(heroProg, [0, 1], [0, 160]);
+  const heroBgScale = useTransform(heroProg, [0, 1], [1.05, 1.2]);
+  const heroOpac    = useTransform(heroProg, [0, 0.7, 1], [1, 0.6, 0]);
+  const heroTitleY  = useTransform(heroProg, [0, 1], [0, -40]);
 
   const [mapType, setMapType] = useState('satellite');
   const mapSrc = mapType === 'satellite' ? SATELLITE_EMBED : HYBRID_EMBED;
 
-  // Reveal advisor chip after scrolling past hero
-  const [showAdvisorChip, setShowAdvisorChip] = useState(false);
+  const [showTopBtn, setShowTopBtn] = useState(false);
   useEffect(() => {
-    const onScroll = () => setShowAdvisorChip(window.scrollY > 500);
+    const onScroll = () => setShowTopBtn(window.scrollY > 600);
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
   return (
-    <div className="min-h-screen bg-[#030509] text-white overflow-x-hidden" style={{ scrollBehavior: 'smooth' }}>
+    <div className="min-h-screen bg-[#030509] text-white overflow-x-hidden">
       <Helmet>
-        <title>Shree Kunj Bihari Enclave — A ₹100 Cr Project | Fanbe Group</title>
-        <meta name="description" content="A flagship ₹100 Crore gated development beside NH-2, near Kosi-Mathura. Industrial growth · Spiritual heritage · Highway access." />
-        <meta property="og:title" content="Shree Kunj Bihari Enclave — A ₹100 Cr Development on NH-2" />
-        <meta property="og:description" content="Premium plots beside the National Highway, Kosi-Mathura. By Fanbe Group." />
+        <title>Shree Kunj Bihari Enclave — Plots near Mathura NH-2 | Fanbe Group</title>
+        <meta name="description" content="Premium gated plots beside NH-2 near Kosi-Mathura. Immediate registry, industrial corridor, spiritual heritage. By Fanbe Group." />
+        <meta property="og:title" content="Shree Kunj Bihari Enclave — Plots near Mathura NH-2" />
+        <meta property="og:description" content="Premium gated plots beside the National Highway, Kosi-Mathura." />
         <meta property="og:image" content={HERO} />
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
         <style>{`
@@ -225,47 +224,30 @@ const KunjBihariLanding = () => {
         `}</style>
       </Helmet>
 
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* HERO — cinematic with parallax + particles + animated reveal         */}
-      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* ════════ HERO ════════ */}
       <section ref={heroRef} className="relative min-h-[100svh] flex flex-col items-center justify-center text-center px-5 overflow-hidden">
         <motion.div style={{ y: heroBgY, scale: heroBgScale, opacity: heroOpac }} className="absolute inset-0 z-0">
           <img src={HERO} alt="" className="w-full h-full object-cover" />
-          <div className="absolute inset-0 bg-gradient-to-b from-[#030509]/30 via-[#030509]/60 to-[#030509]" />
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_25%,rgba(245,158,11,0.22),transparent_55%),radial-gradient(circle_at_75%_80%,rgba(139,92,246,0.12),transparent_60%)]" />
+          <div className="absolute inset-0 bg-gradient-to-b from-[#030509]/30 via-[#030509]/65 to-[#030509]" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_25%,rgba(245,158,11,0.22),transparent_55%)]" />
         </motion.div>
-        <Particles count={40} />
+        <Particles count={36} />
 
         <motion.div style={{ y: heroTitleY }} className="relative z-10 max-w-md mx-auto">
-          {/* ₹100 Cr seal */}
           <motion.div
-            initial={{ opacity: 0, scale: 0.8, y: -10 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            transition={{ delay: 0.2, type: 'spring', stiffness: 200 }}
-            className="relative inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-amber-500/20 via-amber-400/30 to-amber-500/20 border border-amber-400/50 backdrop-blur-md mb-6"
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ delay: 0.2, type: 'spring' }}
+            className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-amber-500/10 border border-amber-500/40 backdrop-blur-sm mb-6"
           >
-            <Crown className="w-4 h-4 text-amber-300" />
-            <span className="text-[10px] font-black tracking-[0.25em] uppercase gold-text">A ₹100 Crore Development</span>
-            <Crown className="w-4 h-4 text-amber-300" />
-            <span
-              className="absolute -inset-px rounded-full opacity-60"
-              style={{
-                background: 'linear-gradient(120deg, transparent 30%, rgba(252,211,77,0.4) 50%, transparent 70%)',
-                backgroundSize: '200% 100%',
-                animation: 'shine 3.5s infinite',
-                mixBlendMode: 'overlay',
-              }}
-            />
+            <Sparkles className="w-3.5 h-3.5 text-amber-400" />
+            <span className="text-[10px] font-bold tracking-[0.25em] uppercase gold-text">A Fanbe Group Project</span>
           </motion.div>
 
-          {/* Letter-by-letter title */}
           <motion.h1
             className="text-[44px] sm:text-[52px] leading-[0.95] font-black tracking-tighter mb-3"
             initial="hidden" animate="visible"
-            variants={{
-              hidden: {},
-              visible: { transition: { staggerChildren: 0.04, delayChildren: 0.3 } },
-            }}
+            variants={{ hidden: {}, visible: { transition: { staggerChildren: 0.04, delayChildren: 0.4 } } }}
           >
             {'Shree Kunj Bihari'.split('').map((ch, i) => (
               <motion.span
@@ -276,9 +258,7 @@ const KunjBihariLanding = () => {
                   visible: { opacity: 1, y: 0, rotateX: 0, transition: { type: 'spring', damping: 12 } },
                 }}
                 style={{ transformOrigin: 'center bottom' }}
-              >
-                {ch === ' ' ? ' ' : ch}
-              </motion.span>
+              >{ch === ' ' ? ' ' : ch}</motion.span>
             ))}
             <br/>
             {'Enclave'.split('').map((ch, i) => (
@@ -290,15 +270,13 @@ const KunjBihariLanding = () => {
                   visible: { opacity: 1, y: 0, rotateX: 0, transition: { type: 'spring', damping: 12 } },
                 }}
                 style={{ transformOrigin: 'center bottom' }}
-              >
-                {ch}
-              </motion.span>
+              >{ch}</motion.span>
             ))}
           </motion.h1>
 
           <motion.p
             initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 1.4 }}
-            className="text-amber-200/90 text-[13px] font-bold tracking-[0.3em] uppercase mb-3"
+            className="text-amber-200/90 text-[13px] font-bold tracking-[0.3em] uppercase mb-4"
           >
             कोसी · मथुरा · NH-2
           </motion.p>
@@ -306,13 +284,13 @@ const KunjBihariLanding = () => {
             initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 1.6 }}
             className="text-white/70 text-[15px] leading-relaxed mb-10 px-3"
           >
-            A flagship ₹100 Crore development beside India's most legendary highway —
-            divinity, industry, and infrastructure converge at one address.
+            Premium gated plots beside India's most legendary highway —
+            divinity, industry, and infrastructure meet at one address.
           </motion.p>
 
           <motion.div
-            initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 2 }}
-            className="flex flex-col items-center gap-3"
+            initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 1.9 }}
+            className="flex flex-col items-center gap-2"
           >
             <motion.div
               animate={{ y: [0, 8, 0] }}
@@ -320,26 +298,24 @@ const KunjBihariLanding = () => {
               className="inline-flex items-center gap-2 text-amber-400/80 text-[10px] font-bold tracking-[0.3em]"
             >
               <ArrowDown className="w-3.5 h-3.5" />
-              <span>SCROLL TO BEGIN THE JOURNEY</span>
+              <span>EXPLORE THE LOCATION</span>
               <ArrowDown className="w-3.5 h-3.5" />
             </motion.div>
           </motion.div>
         </motion.div>
       </section>
 
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* FLOATING STATS (3D flip-in)                                          */}
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 -mt-16 relative z-30">
+      {/* ════════ STATS ════════ */}
+      <section className="px-5 -mt-12 relative z-30">
         <div className="grid grid-cols-2 gap-3 max-w-md mx-auto" style={{ perspective: 1000 }}>
           {STATS.map((s, i) => (
             <motion.div
               key={s.label}
-              initial={{ opacity: 0, rotateY: -90, z: -100 }}
-              whileInView={{ opacity: 1, rotateY: 0, z: 0 }}
+              initial={{ opacity: 0, rotateY: -90 }}
+              whileInView={{ opacity: 1, rotateY: 0 }}
               viewport={{ once: true, margin: '-30px' }}
               transition={{ delay: i * 0.1, type: 'spring', damping: 14 }}
-              className="p-4 rounded-2xl bg-gradient-to-br from-white/[0.07] to-white/[0.02] border border-white/15 backdrop-blur-xl shadow-2xl"
+              className="p-4 rounded-2xl bg-gradient-to-br from-white/[0.07] to-white/[0.02] border border-white/15 backdrop-blur-xl"
               style={{ transformStyle: 'preserve-3d' }}
             >
               <s.icon className="w-5 h-5 mb-2" style={{ color: s.accent }} />
@@ -354,181 +330,37 @@ const KunjBihariLanding = () => {
       </section>
 
       {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* OPPORTUNITY HIGHLIGHT — animated counters                            */}
+      {/* ① LOCATION                                                            */}
       {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 pt-24 pb-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">The Numbers</p>
-        <h2 className="text-3xl font-black leading-tight mb-8">
-          A development at <span className="gold-text">scale</span>
-        </h2>
-
-        <div className="grid grid-cols-3 gap-3">
-          {[
-            { v: 100, suffix: 'Cr',  label: 'Project Worth',  prefix: '₹' },
-            { v: 22,  suffix: '%',   label: 'NH-2 Growth/yr', prefix: '+' },
-            { v: 9,   suffix: '+',   label: 'Plot Sizes',     prefix: '' },
-          ].map((n, i) => (
-            <motion.div
-              key={n.label}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ delay: i * 0.1 }}
-              className="text-center p-3 rounded-2xl bg-white/[0.03] border border-amber-500/20"
-            >
-              <div className="text-2xl font-black gold-text">
-                {n.prefix}<Counter to={n.v} />{n.suffix}
-              </div>
-              <div className="text-[10px] text-white/50 mt-1 font-medium uppercase tracking-wider">{n.label}</div>
-            </motion.div>
-          ))}
-        </div>
-      </section>
-
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* NH-2 STICKY SCROLLYTELLING JOURNEY                                   */}
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      <section ref={journeyRef} className="relative" style={{ height: '220vh' }}>
-        <div className="sticky top-0 h-screen flex items-center justify-center px-5 overflow-hidden">
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(245,158,11,0.08),transparent_70%)]" />
-
-          <div className="relative max-w-md w-full">
-            <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-2 text-center">The Mathura Corridor</p>
-            <h2 className="text-3xl font-black leading-tight mb-4 text-center">
-              On the spine of <span className="gold-text">NH-2</span>
-            </h2>
-
-            <div className="relative rounded-3xl border border-white/10 bg-gradient-to-b from-[#070A12] via-[#0A0F1C] to-[#070A12] p-5 overflow-hidden" style={{ height: '60vh' }}>
-              {/* Highway */}
-              <div className="absolute left-1/2 top-8 bottom-8 w-1 -ml-0.5 bg-gradient-to-b from-amber-400/0 via-amber-400/30 to-amber-400/0" />
-              <div className="absolute left-1/2 top-8 bottom-8 w-px -ml-px"
-                   style={{ backgroundImage: 'linear-gradient(to bottom, rgba(252,211,77,0.7) 50%, transparent 50%)', backgroundSize: '4px 14px' }} />
-
-              {/* Highway label */}
-              <div className="absolute left-1/2 top-2 -translate-x-1/2 text-[9px] font-black tracking-[0.3em] text-amber-400/80 bg-[#070A12] px-2">
-                NH-2
-              </div>
-
-              {/* Cars travelling */}
-              <motion.div
-                style={{ top: carY }}
-                className="absolute left-1/2 -translate-x-1/2 z-30"
-              >
-                <div className="relative">
-                  <div className="absolute inset-0 -m-4 rounded-full bg-amber-500/40 blur-lg animate-pulse" />
-                  <div className="relative w-4 h-7 rounded-md bg-gradient-to-b from-amber-300 to-amber-600 shadow-lg shadow-amber-500/50" />
-                </div>
-              </motion.div>
-
-              {/* Corridor cities */}
-              <div className="relative h-full flex flex-col justify-around py-4">
-                {CORRIDOR.map((c, i) => (
-                  <div key={c.name} className="relative grid grid-cols-2 items-center gap-2 h-8">
-                    {c.side === 'left' && (
-                      <>
-                        <motion.div
-                          initial={{ opacity: 0, x: -20 }} whileInView={{ opacity: 1, x: 0 }} viewport={{ once: true, margin: '-10%' }}
-                          transition={{ delay: i * 0.05 }}
-                          className="text-right pr-4"
-                        >
-                          <div className="font-bold text-[12px] text-white">{c.name}</div>
-                          <div className="text-[9px] text-white/40 font-medium">{c.dist} · {c.drive}</div>
-                        </motion.div>
-                        <div />
-                      </>
-                    )}
-                    {c.side === 'right' && (
-                      <>
-                        <div />
-                        <motion.div
-                          initial={{ opacity: 0, x: 20 }} whileInView={{ opacity: 1, x: 0 }} viewport={{ once: true, margin: '-10%' }}
-                          transition={{ delay: i * 0.05 }}
-                          className="text-left pl-4"
-                        >
-                          <div className="font-bold text-[12px] text-white">{c.name}</div>
-                          <div className="text-[9px] text-white/40 font-medium">{c.dist} · {c.drive}</div>
-                        </motion.div>
-                      </>
-                    )}
-                    {c.side === 'pin' && (
-                      <div className="col-span-2 flex items-center justify-center">
-                        <motion.div
-                          initial={{ scale: 0, opacity: 0 }}
-                          whileInView={{ scale: 1, opacity: 1 }}
-                          viewport={{ once: true }}
-                          transition={{ type: 'spring', damping: 12, delay: 0.2 }}
-                          className="relative"
-                        >
-                          <div className="absolute inset-0 -m-6 rounded-full"
-                               style={{ animation: 'pulseRing 1.6s infinite ease-out', background: 'radial-gradient(circle, rgba(252,211,77,0.6), transparent 70%)' }} />
-                          <div className="absolute inset-0 -m-3 rounded-full"
-                               style={{ animation: 'pulseRing 1.6s 0.4s infinite ease-out', background: 'radial-gradient(circle, rgba(252,211,77,0.7), transparent 70%)' }} />
-                          <div className="relative px-4 py-2 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-[#030509] text-[10px] font-black tracking-widest shadow-2xl shadow-amber-500/60">
-                            ★ KOSI ★
-                          </div>
-                        </motion.div>
-                      </div>
-                    )}
-
-                    {/* milestone dot */}
-                    {!c.highlight && (
-                      <div className="absolute left-1/2 -translate-x-1/2 w-2 h-2 rounded-full bg-amber-400/50 border border-amber-400/70" />
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <p className="text-center text-[10px] text-white/40 mt-4 font-medium tracking-wider">
-              SHREE KUNJ BIHARI ENCLAVE · KOSI, MATHURA
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* SATELLITE MAP — cinematic flyover                                    */}
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      <section ref={mapRef} className="px-5 pt-12 pb-12 max-w-md mx-auto" style={{ perspective: 1400 }}>
-        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">Live Satellite View</p>
+      <section className="px-5 pt-24 pb-10 max-w-md mx-auto">
+        <SectionLabel>① Location</SectionLabel>
         <h2 className="text-3xl font-black leading-tight mb-2">
-          See it from <span className="gold-text">above</span>
+          The exact <span className="gold-text">spot</span>
         </h2>
         <p className="text-white/60 text-[14px] leading-relaxed mb-6">
-          The land, the highway, the railway — all in one frame.
+          Kosi Kalan, Mathura — beside NH-2, walking distance to Shanidev Temple and Durwasha Rishi Ashram.
         </p>
 
-        <motion.div
-          style={{ scale: mapScale, rotateZ: mapRotZ, transformStyle: 'preserve-3d' }}
-          className="relative rounded-3xl overflow-hidden border border-white/20 bg-[#0A0F1C] shadow-2xl shadow-amber-500/10"
-        >
-          {/* Type toggle */}
+        {/* Satellite map */}
+        <div className="relative rounded-3xl overflow-hidden border border-white/15 bg-[#0A0F1C] shadow-2xl shadow-amber-500/10">
           <div className="absolute top-3 left-3 z-10 flex gap-1 p-1 rounded-full bg-black/70 backdrop-blur-md border border-white/15">
             <button
               onClick={() => setMapType('satellite')}
-              className={`px-3 py-1.5 rounded-full text-[10px] font-bold tracking-wide flex items-center gap-1 transition ${
-                mapType === 'satellite' ? 'bg-amber-400 text-[#030509] shadow-md' : 'text-white/70'
-              }`}
+              className={`px-3 py-1.5 rounded-full text-[10px] font-bold tracking-wide flex items-center gap-1 transition ${mapType === 'satellite' ? 'bg-amber-400 text-[#030509]' : 'text-white/70'}`}
             >
               <Mountain className="w-3 h-3" /> SATELLITE
             </button>
             <button
               onClick={() => setMapType('hybrid')}
-              className={`px-3 py-1.5 rounded-full text-[10px] font-bold tracking-wide flex items-center gap-1 transition ${
-                mapType === 'hybrid' ? 'bg-amber-400 text-[#030509] shadow-md' : 'text-white/70'
-              }`}
+              className={`px-3 py-1.5 rounded-full text-[10px] font-bold tracking-wide flex items-center gap-1 transition ${mapType === 'hybrid' ? 'bg-amber-400 text-[#030509]' : 'text-white/70'}`}
             >
               <Layers className="w-3 h-3" /> LABELS
             </button>
           </div>
-
-          {/* Coordinates */}
           <div className="absolute top-3 right-3 z-10 px-2.5 py-1.5 rounded-full bg-black/70 backdrop-blur-md border border-emerald-400/30 flex items-center gap-1.5">
             <div className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
             <span className="text-[9px] font-mono font-bold text-emerald-300 tracking-wider">27.79°N 77.44°E</span>
           </div>
-
-          {/* Animated crosshair overlay */}
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 pointer-events-none">
             <div className="relative w-16 h-16">
               <div className="absolute inset-0 rounded-full border border-amber-400/60" style={{ animation: 'pulseRing 2s infinite ease-out' }} />
@@ -542,7 +374,7 @@ const KunjBihariLanding = () => {
             src={mapSrc}
             title="Shree Kunj Bihari Enclave Location"
             className="w-full aspect-square block"
-            style={{ border: 0, filter: 'contrast(1.08) saturate(1.15) brightness(1.05)' }}
+            style={{ border: 0, filter: 'contrast(1.05) saturate(1.1) brightness(1.05)' }}
             loading="lazy"
             referrerPolicy="no-referrer-when-downgrade"
           />
@@ -553,112 +385,214 @@ const KunjBihariLanding = () => {
                 <Compass className="w-4 h-4 text-amber-400" />
                 <div>
                   <div className="text-[11px] font-bold">Kosi Kalan · Mathura</div>
-                  <div className="text-[9px] text-white/50 tracking-wide">NH-2 Corridor, Uttar Pradesh</div>
+                  <div className="text-[9px] text-white/50">NH-2 Corridor, Uttar Pradesh</div>
                 </div>
               </div>
               <a
                 href={MAPS_LINK} target="_blank" rel="noreferrer"
-                className="text-[10px] font-bold text-amber-400 border border-amber-400/40 rounded-full px-3 py-1.5 hover:bg-amber-400/10 transition"
+                className="text-[10px] font-bold text-amber-400 border border-amber-400/40 rounded-full px-3 py-1.5"
               >
                 Open in Maps ↗
               </a>
             </div>
           </div>
-        </motion.div>
-
-        <p className="text-center text-[10px] text-white/40 mt-3 tracking-wider">PINCH TO ZOOM · IMAGERY © GOOGLE</p>
-      </section>
-
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* OPPORTUNITY (4 cards)                                                 */}
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 pt-16 pb-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">The Opportunity</p>
-        <h2 className="text-3xl font-black leading-tight mb-5">
-          Where divinity meets <span className="gold-text">growth</span>
-        </h2>
-
-        <div className="space-y-3" style={{ perspective: 1200 }}>
-          {[
-            { icon: '🛣️', title: 'Highway-front access',  desc: 'NH-2 expressway in 5 minutes — Delhi reachable in 90 minutes.' },
-            { icon: '🏭', title: 'Industrial powerhouse',  desc: 'Plants of Maruti Suzuki, Reliance, Bharat Forge, Havells & 5+ MNCs nearby.' },
-            { icon: '🛕', title: 'Spiritual gravity',      desc: 'Mathura, Vrindavan, Govardhan & Shani Dev Mandir — the heart of Braj Bhoomi.' },
-            { icon: '📈', title: 'Appreciation corridor',  desc: 'NH-2 land prices have grown ~22% YoY in this belt.' },
-          ].map((b, i) => (
-            <motion.div
-              key={b.title}
-              initial={{ opacity: 0, x: -20, rotateY: -8 }}
-              whileInView={{ opacity: 1, x: 0, rotateY: 0 }}
-              viewport={{ once: true }}
-              transition={{ delay: i * 0.08 }}
-              className="flex gap-4 p-4 rounded-2xl bg-gradient-to-br from-white/[0.05] to-transparent border border-white/10"
-              style={{ transformStyle: 'preserve-3d' }}
-            >
-              <div className="text-3xl flex-shrink-0">{b.icon}</div>
-              <div>
-                <h3 className="font-bold text-[15px] mb-0.5">{b.title}</h3>
-                <p className="text-white/60 text-[13px] leading-relaxed">{b.desc}</p>
-              </div>
-            </motion.div>
-          ))}
         </div>
-      </section>
 
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* LANDMARKS                                                            */}
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 py-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">Around You</p>
-        <h2 className="text-3xl font-black mb-6">Every landmark, <span className="gold-text">minutes away</span></h2>
-
-        <div className="space-y-2.5">
+        {/* Landmarks */}
+        <div className="mt-6 space-y-2.5">
           {LANDMARKS.map((l, i) => (
             <motion.div
               key={l.name}
-              initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: true }}
-              transition={{ delay: i * 0.05 }}
-              className="flex items-center gap-4 p-3.5 rounded-xl bg-gradient-to-r from-white/[0.05] to-transparent border border-white/[0.08]"
+              initial={{ opacity: 0, x: -10 }} whileInView={{ opacity: 1, x: 0 }} viewport={{ once: true }}
+              transition={{ delay: i * 0.04 }}
+              className="flex items-center gap-3 p-3 rounded-xl bg-white/[0.04] border border-white/[0.08]"
             >
-              <div className="w-11 h-11 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center text-xl flex-shrink-0">
-                {l.emoji}
-              </div>
+              <div className="w-10 h-10 rounded-lg bg-white/5 border border-white/10 flex items-center justify-center text-lg flex-shrink-0">{l.emoji}</div>
               <div className="flex-1 min-w-0">
                 <div className="font-bold text-[14px] truncate">{l.name}</div>
                 <div className="text-[10px] text-amber-400/70 uppercase tracking-wider font-semibold">{l.tag}</div>
               </div>
-              <div className="text-right flex-shrink-0">
-                <div className="font-black text-amber-400 text-sm">{l.dist}</div>
-              </div>
+              <div className="font-black text-amber-400 text-sm">{l.dist}</div>
             </motion.div>
           ))}
         </div>
       </section>
 
       {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* INDUSTRIAL BRANDS — infinite marquee                                 */}
+      {/* ② CONNECTIVITY                                                       */}
       {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="py-16 overflow-hidden">
+      <section className="px-5 pt-16 pb-10 max-w-md mx-auto">
+        <SectionLabel>② Connectivity</SectionLabel>
+        <h2 className="text-3xl font-black leading-tight mb-2">
+          On the spine of <span className="gold-text">NH-2</span>
+        </h2>
+        <p className="text-white/60 text-[14px] leading-relaxed mb-6">
+          The Delhi-Agra national corridor runs past your front gate.
+        </p>
+
+        {/* Compact NH-2 corridor */}
+        <div className="relative rounded-3xl border border-white/10 bg-gradient-to-b from-[#070A12] to-[#080B14] p-5 overflow-hidden mb-5">
+          <div className="absolute left-1/2 top-8 bottom-6 w-1 -ml-0.5 bg-gradient-to-b from-amber-400/0 via-amber-400/30 to-amber-400/0" />
+          <div className="absolute left-1/2 top-8 bottom-6 w-px -ml-px"
+               style={{ backgroundImage: 'linear-gradient(to bottom, rgba(252,211,77,0.7) 50%, transparent 50%)', backgroundSize: '4px 14px' }} />
+          <div className="absolute left-1/2 top-1.5 -translate-x-1/2 text-[9px] font-black tracking-[0.3em] text-amber-400/80 bg-[#080B14] px-2">NH-2</div>
+
+          <div className="relative flex flex-col gap-3">
+            {CORRIDOR.map((c, i) => (
+              <motion.div
+                key={c.name}
+                initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: true }}
+                transition={{ delay: i * 0.05 }}
+                className="relative grid grid-cols-2 items-center gap-2 h-10"
+              >
+                {c.side === 'left' && (
+                  <>
+                    <div className="text-right pr-4">
+                      <div className="font-bold text-[12px]">{c.name}</div>
+                      <div className="text-[9px] text-white/40">{c.km} · {c.drive}</div>
+                    </div>
+                    <div />
+                    <div className="absolute left-1/2 -translate-x-1/2 w-2 h-2 rounded-full bg-amber-400/50 border border-amber-400/70" />
+                  </>
+                )}
+                {c.side === 'right' && (
+                  <>
+                    <div />
+                    <div className="text-left pl-4">
+                      <div className="font-bold text-[12px]">{c.name}</div>
+                      <div className="text-[9px] text-white/40">{c.km} · {c.drive}</div>
+                    </div>
+                    <div className="absolute left-1/2 -translate-x-1/2 w-2 h-2 rounded-full bg-amber-400/50 border border-amber-400/70" />
+                  </>
+                )}
+                {c.side === 'pin' && (
+                  <div className="col-span-2 flex items-center justify-center">
+                    <motion.div
+                      initial={{ scale: 0, opacity: 0 }}
+                      whileInView={{ scale: 1, opacity: 1 }}
+                      viewport={{ once: true }}
+                      transition={{ type: 'spring', damping: 12 }}
+                      className="relative"
+                    >
+                      <div className="absolute inset-0 -m-3 rounded-full"
+                           style={{ animation: 'pulseRing 1.6s infinite ease-out', background: 'radial-gradient(circle, rgba(252,211,77,0.7), transparent 70%)' }} />
+                      <div className="relative px-4 py-2 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-[#030509] text-[10px] font-black tracking-widest shadow-lg shadow-amber-500/50">
+                        ★ KOSI · YOU ARE HERE ★
+                      </div>
+                    </motion.div>
+                  </div>
+                )}
+              </motion.div>
+            ))}
+          </div>
+        </div>
+
+        {/* Connectivity table */}
+        <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-amber-500/5 to-transparent p-1">
+          <div className="rounded-[1.4rem] bg-[#0A0F1C]/60 backdrop-blur p-4">
+            <p className="text-[10px] font-bold text-white/50 uppercase tracking-wider mb-2 px-2">Drive Times</p>
+            {CONNECTIVITY.map((c, i) => (
+              <div key={c.place} className={`flex items-center justify-between py-2.5 px-2 ${i < CONNECTIVITY.length - 1 ? 'border-b border-white/5' : ''}`}>
+                <div className="flex items-center gap-3">
+                  <Clock className="w-3.5 h-3.5 text-amber-400/70" />
+                  <span className="font-semibold text-[14px]">{c.place}</span>
+                </div>
+                <div className="text-right">
+                  <div className="font-black text-white text-sm">{c.time}</div>
+                  <div className="text-[10px] text-white/40">{c.km}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* ③ INFRASTRUCTURE                                                     */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="px-5 pt-16 pb-10 max-w-md mx-auto">
+        <SectionLabel>③ Infrastructure</SectionLabel>
+        <h2 className="text-3xl font-black leading-tight mb-2">
+          Built like a <span className="gold-text">forever home</span>
+        </h2>
+        <p className="text-white/60 text-[14px] leading-relaxed mb-6">
+          Engineered amenities inside a gated boundary.
+        </p>
+
+        <div className="grid grid-cols-2 gap-3" style={{ perspective: 800 }}>
+          {INFRA.map((f, i) => (
+            <motion.div
+              key={f.title}
+              initial={{ opacity: 0, y: 20, rotateY: -8 }}
+              whileInView={{ opacity: 1, y: 0, rotateY: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.06 }}
+              className="p-4 rounded-2xl bg-white/[0.04] border border-white/10"
+              style={{ transformStyle: 'preserve-3d' }}
+            >
+              <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-3 bg-amber-500/15 border border-amber-500/30">
+                <f.icon className="w-5 h-5 text-amber-400" />
+              </div>
+              <h3 className="font-bold text-sm mb-0.5">{f.title}</h3>
+              <p className="text-white/60 text-[11px] leading-relaxed">{f.desc}</p>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      {/* ④ INDUSTRY — with real logos                                         */}
+      {/* ════════════════════════════════════════════════════════════════════ */}
+      <section className="pt-16 pb-10">
         <div className="px-5 max-w-md mx-auto mb-6">
-          <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">Industrial Neighbors</p>
-          <h2 className="text-3xl font-black">
-            The brands that <span className="gold-text">moved here first</span>
+          <SectionLabel>④ Industry</SectionLabel>
+          <h2 className="text-3xl font-black leading-tight mb-2">
+            Anchored by <span className="gold-text">global manufacturers</span>
           </h2>
-          <p className="text-white/60 text-[13px] leading-relaxed mt-3">
-            When global manufacturers anchor a corridor, land value follows.
+          <p className="text-white/60 text-[14px] leading-relaxed">
+            When companies of this scale build their plants in a corridor, land prices follow.
           </p>
         </div>
 
-        <div className="relative">
+        {/* Logo grid */}
+        <div className="px-5 max-w-md mx-auto grid grid-cols-3 gap-2.5 mb-6">
+          {BRANDS.map((b, i) => (
+            <motion.div
+              key={b.name}
+              initial={{ opacity: 0, scale: 0.9 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.05 }}
+              className="aspect-square rounded-2xl bg-white border border-white/10 flex flex-col items-center justify-center p-2 gap-1 shadow-lg"
+            >
+              <img
+                src={`https://logo.clearbit.com/${b.domain}`}
+                alt={b.name}
+                className="max-h-9 max-w-full object-contain"
+                loading="lazy"
+                onError={(e) => { e.target.style.display = 'none'; }}
+              />
+              <span className="text-[9px] font-bold text-gray-800 text-center leading-tight">{b.name}</span>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Marquee strip */}
+        <div className="relative overflow-hidden">
           <div className="absolute inset-y-0 left-0 w-12 bg-gradient-to-r from-[#030509] to-transparent z-10 pointer-events-none" />
           <div className="absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-[#030509] to-transparent z-10 pointer-events-none" />
-          <div className="flex gap-3 overflow-hidden" style={{ width: '100%' }}>
-            <div className="flex gap-3 shrink-0" style={{ animation: 'marquee 28s linear infinite' }}>
+          <div className="flex gap-2.5" style={{ width: 'max-content' }}>
+            <div className="flex gap-2.5 shrink-0" style={{ animation: 'marquee 28s linear infinite' }}>
               {[...BRANDS, ...BRANDS].map((b, i) => (
-                <div
-                  key={i}
-                  className="shrink-0 min-w-[120px] h-16 rounded-2xl bg-gradient-to-br from-white/[0.07] to-white/[0.02] border border-white/10 flex items-center justify-center px-4"
-                >
-                  <span className="text-[12px] font-bold text-white/90 text-center">{b}</span>
+                <div key={i} className="shrink-0 h-12 px-4 rounded-xl bg-white flex items-center gap-2">
+                  <img
+                    src={`https://logo.clearbit.com/${b.domain}`}
+                    alt={b.name}
+                    className="max-h-6 max-w-[40px] object-contain"
+                    loading="lazy"
+                    onError={(e) => { e.target.style.display = 'none'; }}
+                  />
+                  <span className="text-[10px] font-bold text-gray-800">{b.name}</span>
                 </div>
               ))}
             </div>
@@ -667,147 +601,28 @@ const KunjBihariLanding = () => {
       </section>
 
       {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* PRICING — 3D tilted card                                             */}
+      {/* ⑤ SECURITY                                                            */}
       {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 py-12 max-w-md mx-auto" style={{ perspective: 1200 }}>
-        <Tilt3D intensity={6}>
-          <div className="relative rounded-[2rem] overflow-hidden shadow-2xl shadow-amber-500/30">
-            <div className="absolute inset-0 bg-gradient-to-br from-amber-400 via-orange-500 to-amber-600" />
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.25),transparent_55%)]" />
-            <span
-              className="absolute -inset-px opacity-50 pointer-events-none"
-              style={{
-                background: 'linear-gradient(120deg, transparent 30%, rgba(255,255,255,0.4) 50%, transparent 70%)',
-                backgroundSize: '200% 100%',
-                animation: 'shine 4s infinite',
-              }}
-            />
-            <div className="relative p-7 text-[#030509]">
-              <p className="text-[11px] font-bold tracking-[0.25em] uppercase opacity-70 mb-2">Plots Starting From</p>
-              <div className="flex items-baseline gap-2 mb-1">
-                <span className="text-xs font-black opacity-80">₹</span>
-                <span className="text-6xl font-black tracking-tight">
-                  <Counter to={7525} />
-                </span>
-              </div>
-              <p className="text-sm font-bold opacity-80 mb-5">per square yard</p>
+      <section className="px-5 pt-16 pb-10 max-w-md mx-auto">
+        <SectionLabel>⑤ Security</SectionLabel>
+        <h2 className="text-3xl font-black leading-tight mb-6">
+          A community you can <span className="text-blue-400">leave at the gate</span>
+        </h2>
 
-              <div className="grid grid-cols-3 gap-2 mb-2">
-                {[
-                  { v: 10, label: 'Booking' },
-                  { v: 35, label: 'Registry' },
-                  { v: 60, label: 'Mo EMI' },
-                ].map(x => (
-                  <div key={x.label} className="text-center py-3 bg-black/15 rounded-xl">
-                    <div className="text-xl font-black"><Counter to={x.v} />{x.label === 'Booking' || x.label === 'Registry' ? '%' : ''}</div>
-                    <div className="text-[10px] font-bold uppercase opacity-70">{x.label}</div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        </Tilt3D>
-
-        {/* Plot size grid */}
-        <div className="grid grid-cols-2 gap-3 mt-6">
-          {PLOTS.map((p, i) => (
-            <motion.div
-              key={p.size}
-              initial={{ opacity: 0, y: 20, rotateX: -10 }}
-              whileInView={{ opacity: 1, y: 0, rotateX: 0 }}
-              viewport={{ once: true }}
-              transition={{ delay: i * 0.06 }}
-              className={`relative p-4 rounded-2xl border ${p.highlight ? 'bg-gradient-to-br from-amber-500/10 to-amber-500/0 border-amber-400/40' : 'bg-white/[0.03] border-white/10'}`}
-              style={{ transformStyle: 'preserve-3d' }}
-            >
-              {p.highlight && (
-                <div className="absolute -top-2 right-3 text-[8px] font-black px-2 py-0.5 rounded-full bg-amber-400 text-[#030509] tracking-wider">
-                  POPULAR
-                </div>
-              )}
-              <div className="text-[10px] text-white/40 font-bold uppercase tracking-wider mb-1">Plot</div>
-              <div className="text-2xl font-black mb-3">{p.size} <span className="text-[11px] text-white/50 font-medium">sq yd</span></div>
-              <div className="flex items-baseline gap-1 mb-1">
-                <span className="text-[10px] text-white/40">Total</span>
-                <span className="text-sm font-bold text-white">₹{(p.total/100000).toFixed(2)}L</span>
-              </div>
-              <div className="flex items-baseline gap-1">
-                <span className="text-[10px] text-amber-400/80">EMI</span>
-                <span className="text-sm font-bold text-amber-400">₹{p.emi.toLocaleString('en-IN')}</span>
-                <span className="text-[10px] text-amber-400/60">/mo</span>
-              </div>
-            </motion.div>
-          ))}
-        </div>
-      </section>
-
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* INFRASTRUCTURE                                                       */}
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 py-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3">Inside the Gates</p>
-        <h2 className="text-3xl font-black mb-6">Built like a <span className="gold-text">forever home</span></h2>
-
-        <div className="grid grid-cols-2 gap-3" style={{ perspective: 800 }}>
-          {INFRA.map((f, i) => (
-            <motion.div
-              key={f.title}
-              initial={{ opacity: 0, y: 30, rotateY: -10 }}
-              whileInView={{ opacity: 1, y: 0, rotateY: 0 }}
-              viewport={{ once: true }}
-              transition={{ delay: i * 0.06 }}
-              className="p-4 rounded-2xl bg-white/[0.04] border border-white/10"
-              style={{ transformStyle: 'preserve-3d' }}
-            >
-              <div className="w-10 h-10 rounded-xl flex items-center justify-center mb-3" style={{ background: `${f.color}25`, border: `1px solid ${f.color}50` }}>
-                <f.icon className="w-5 h-5" style={{ color: f.color }} />
-              </div>
-              <h3 className="font-bold text-sm mb-1">{f.title}</h3>
-              <p className="text-white/60 text-[11px] leading-relaxed">{f.desc}</p>
-            </motion.div>
-          ))}
-        </div>
-      </section>
-
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* TRUST BADGES                                                         */}
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 py-12 max-w-md mx-auto">
-        <p className="text-amber-400 text-xs font-bold tracking-[0.25em] uppercase mb-3 text-center">Investor Assurance</p>
-        <h2 className="text-3xl font-black text-center mb-6">Promises we <span className="gold-text">put in writing</span></h2>
-
-        <div className="grid grid-cols-2 gap-3">
-          {TRUST.map((t, i) => (
-            <motion.div
-              key={t.label}
-              initial={{ opacity: 0, scale: 0.85 }}
-              whileInView={{ opacity: 1, scale: 1 }}
-              viewport={{ once: true }}
-              transition={{ delay: i * 0.07, type: 'spring' }}
-              className="p-5 rounded-2xl bg-gradient-to-br from-amber-500/10 to-white/[0.02] border border-amber-500/30 text-center"
-            >
-              <t.icon className="w-7 h-7 mx-auto text-amber-400 mb-2" />
-              <div className="font-bold text-sm">{t.label}</div>
-            </motion.div>
-          ))}
-        </div>
-      </section>
-
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* SECURITY                                                             */}
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 py-12 max-w-md mx-auto">
-        <div className="relative rounded-[2rem] overflow-hidden border border-white/10 bg-gradient-to-br from-blue-900/30 via-[#0A0F1C] to-[#0A0F1C] p-7">
-          <Shield className="w-12 h-12 text-blue-400 mb-4" />
-          <h2 className="text-2xl font-black mb-3">A community you can <span className="text-blue-400">leave at the gate</span></h2>
-          <p className="text-white/70 text-[14px] leading-relaxed mb-5">
-            Closed boundary. Single entry. 24×7 trained guards. CCTV at gate and access points.
-            Only authorized vehicles inside.
+        <div className="relative rounded-[2rem] overflow-hidden border border-blue-500/20 bg-gradient-to-br from-blue-900/30 via-[#0A0F1C] to-[#0A0F1C] p-6">
+          <Shield className="w-10 h-10 text-blue-400 mb-3" />
+          <p className="text-white/75 text-[14px] leading-relaxed mb-5">
+            Closed boundary. Single entry. 24×7 trained guards. CCTV at gate and access points. Only authorized vehicles inside.
           </p>
-          <div className="grid grid-cols-2 gap-3 text-[12px]">
-            {['24×7 guards', 'CCTV gate', 'Closed boundary', 'Authorized entry only'].map(b => (
-              <div key={b} className="flex items-center gap-2 text-white/80">
-                <CheckCircle2 className="w-4 h-4 text-green-400 flex-shrink-0" />
+          <div className="grid grid-cols-2 gap-2.5">
+            {[
+              '24×7 trained guards',
+              'CCTV at every gate',
+              'Closed boundary wall',
+              'Authorized entry only',
+            ].map(b => (
+              <div key={b} className="flex items-center gap-2 text-[12px] text-white/85">
+                <CheckCircle2 className="w-4 h-4 text-emerald-400 flex-shrink-0" />
                 <span>{b}</span>
               </div>
             ))}
@@ -816,65 +631,166 @@ const KunjBihariLanding = () => {
       </section>
 
       {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* FINALE — Golden seal                                                  */}
+      {/* ⑥ APPRECIATION                                                       */}
       {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 py-24 max-w-md mx-auto text-center relative">
-        <Particles count={20} />
+      <section className="px-5 pt-16 pb-10 max-w-md mx-auto">
+        <SectionLabel>⑥ Appreciation</SectionLabel>
+        <h2 className="text-3xl font-black leading-tight mb-2">
+          Why prices <span className="gold-text">keep climbing here</span>
+        </h2>
+        <p className="text-white/60 text-[14px] leading-relaxed mb-6">
+          Four forces are pulling this corridor up at the same time.
+        </p>
+
+        <div className="space-y-3 mb-8">
+          {APPRECIATION.map((a, i) => (
+            <motion.div
+              key={a.label}
+              initial={{ opacity: 0, x: -10 }} whileInView={{ opacity: 1, x: 0 }} viewport={{ once: true }}
+              transition={{ delay: i * 0.08 }}
+              className="flex items-center gap-4 p-4 rounded-2xl bg-gradient-to-r from-amber-500/10 to-transparent border border-amber-500/20"
+            >
+              <div className="w-12 h-12 rounded-xl bg-amber-500/15 border border-amber-500/30 flex items-center justify-center flex-shrink-0">
+                <a.icon className="w-6 h-6 text-amber-400" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-2xl font-black gold-text leading-none mb-1">{a.stat}</div>
+                <div className="text-[12px] text-white/70 leading-snug">{a.label}</div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Pricing — top-down */}
+        <Tilt3D intensity={5}>
+          <div className="relative rounded-[2rem] overflow-hidden shadow-2xl shadow-amber-500/30">
+            <div className="absolute inset-0 bg-gradient-to-br from-amber-400 via-orange-500 to-amber-600" />
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.25),transparent_55%)]" />
+            <span
+              className="absolute -inset-px opacity-50 pointer-events-none"
+              style={{
+                background: 'linear-gradient(120deg, transparent 30%, rgba(255,255,255,0.4) 50%, transparent 70%)',
+                backgroundSize: '200% 100%', animation: 'shine 4s infinite',
+              }}
+            />
+            <div className="relative p-6 text-[#030509]">
+              <p className="text-[11px] font-bold tracking-[0.25em] uppercase opacity-70 mb-1">Largest plot starts at</p>
+              <div className="flex items-baseline gap-1 mb-5">
+                <span className="text-xs font-black opacity-80">₹</span>
+                <span className="text-5xl font-black tracking-tight"><Counter to={18.81} suffix="L" duration={1.4} /></span>
+                <span className="text-[11px] font-bold opacity-70 ml-1">/ 250 sq yd</span>
+              </div>
+
+              <div className="grid grid-cols-3 gap-2 mb-3">
+                {[
+                  { v: 10, label: 'Booking', sfx: '%' },
+                  { v: 35, label: 'Registry', sfx: '%' },
+                  { v: 60, label: 'Mo EMI',  sfx: '' },
+                ].map(x => (
+                  <div key={x.label} className="text-center py-3 bg-black/15 rounded-xl">
+                    <div className="text-xl font-black"><Counter to={x.v} />{x.sfx}</div>
+                    <div className="text-[10px] font-bold uppercase opacity-70">{x.label}</div>
+                  </div>
+                ))}
+              </div>
+              <p className="text-center text-[10px] font-bold opacity-70">0% Interest · Immediate Registry with 35% payment</p>
+            </div>
+          </div>
+        </Tilt3D>
+
+        {/* Plot ladder — TOP DOWN (largest first) */}
+        <p className="text-[10px] font-bold text-white/50 uppercase tracking-wider mt-6 mb-3">All plot sizes</p>
+        <div className="rounded-3xl border border-white/10 bg-[#0A0F1C]/60 overflow-hidden">
+          <div className="grid grid-cols-3 px-4 py-2.5 bg-white/5 text-[10px] font-bold text-white/50 uppercase tracking-wider">
+            <span>Plot</span>
+            <span className="text-right">Total</span>
+            <span className="text-right">EMI/mo</span>
+          </div>
+          {PLOTS.map((p, i) => (
+            <motion.div
+              key={p.size}
+              initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} viewport={{ once: true }}
+              transition={{ delay: i * 0.04 }}
+              className={`grid grid-cols-3 px-4 py-3 items-center border-t border-white/5 ${p.popular ? 'bg-amber-500/10' : ''}`}
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-bold text-[13px]">{p.size} sq yd</span>
+                {p.popular && <span className="text-[8px] font-black px-1.5 py-0.5 rounded bg-amber-400 text-[#030509]">POPULAR</span>}
+              </div>
+              <div className="text-right font-bold text-[13px]">₹{(p.total/100000).toFixed(2)}L</div>
+              <div className="text-right font-bold text-[13px] text-amber-400">₹{p.emi.toLocaleString('en-IN')}</div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Trust strip */}
+        <div className="grid grid-cols-2 gap-3 mt-8">
+          {TRUST.map((t, i) => (
+            <motion.div
+              key={t.label}
+              initial={{ opacity: 0, scale: 0.9 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.07 }}
+              className="p-4 rounded-2xl bg-gradient-to-br from-amber-500/10 to-white/[0.02] border border-amber-500/30 text-center"
+            >
+              <t.icon className="w-6 h-6 mx-auto text-amber-400 mb-2" />
+              <div className="font-bold text-[12px] leading-tight">{t.label}</div>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+
+      {/* ════════ FINALE ════════ */}
+      <section className="px-5 py-20 max-w-md mx-auto text-center relative">
+        <Particles count={18} />
 
         <motion.div
           initial={{ scale: 0, rotate: -180, opacity: 0 }}
           whileInView={{ scale: 1, rotate: 0, opacity: 1 }}
           viewport={{ once: true }}
           transition={{ type: 'spring', damping: 14, duration: 1.4 }}
-          className="relative inline-block mb-8"
+          className="relative inline-block mb-6"
         >
-          <div className="relative w-28 h-28 rounded-full bg-gradient-to-br from-amber-300 via-amber-500 to-orange-600 shadow-2xl shadow-amber-500/40 flex items-center justify-center">
+          <div className="relative w-24 h-24 rounded-full bg-gradient-to-br from-amber-300 via-amber-500 to-orange-600 shadow-2xl shadow-amber-500/40 flex items-center justify-center">
             <div className="absolute inset-2 rounded-full border-2 border-[#030509]/30" />
-            <Gem className="w-12 h-12 text-[#030509]" />
+            <Gem className="w-10 h-10 text-[#030509]" />
           </div>
-          <div className="absolute inset-0 -m-6 rounded-full"
+          <div className="absolute inset-0 -m-5 rounded-full"
                style={{ animation: 'pulseRing 2.5s infinite ease-out', background: 'radial-gradient(circle, rgba(252,211,77,0.4), transparent 70%)' }} />
         </motion.div>
 
-        <h2 className="text-[44px] font-black leading-[0.95] mb-4 relative z-10">
+        <h2 className="text-[40px] font-black leading-[0.95] mb-3 relative z-10">
           Your plot.<br/>
           <span className="gold-text">Your legacy.</span>
         </h2>
-        <p className="text-white/70 text-[15px] leading-relaxed mb-10 relative z-10">
+        <p className="text-white/70 text-[15px] leading-relaxed mb-8 relative z-10">
           Inventory on the front rows of NH-2 is finite.
-          Speak to the advisor who shared this page with you
-          to lock the plot that fits your goal.
+          Speak to the advisor who shared this page with you.
         </p>
 
         <div className="inline-flex items-center gap-2 px-5 py-3.5 rounded-full bg-gradient-to-r from-amber-500/20 via-amber-400/30 to-amber-500/20 border border-amber-400/50 backdrop-blur-md relative z-10">
           <Sparkles className="w-4 h-4 text-amber-300" />
-          <span className="text-[13px] font-bold gold-text">
-            Continue with your advisor
-          </span>
+          <span className="text-[13px] font-bold gold-text">Continue with your advisor</span>
         </div>
 
-        <p className="mt-14 text-[10px] text-white/40 leading-relaxed tracking-wider relative z-10">
+        <p className="mt-12 text-[10px] text-white/40 leading-relaxed tracking-wider relative z-10">
           SHREE KUNJ BIHARI ENCLAVE · KOSI KALAN · MATHURA, UP<br/>
           A <span className="gold-text font-bold">Fanbe Group</span> Development
         </p>
       </section>
 
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {/* Floating advisor chip after scroll                                   */}
-      {/* ════════════════════════════════════════════════════════════════════ */}
-      {showAdvisorChip && (
-        <motion.div
+      {/* Back to top */}
+      {showTopBtn && (
+        <motion.button
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           initial={{ y: 80, opacity: 0 }} animate={{ y: 0, opacity: 1 }}
           transition={{ type: 'spring', damping: 18 }}
-          className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50"
+          className="fixed bottom-4 right-4 z-50 w-12 h-12 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-[#030509] shadow-2xl shadow-amber-500/50 active:scale-95 transition flex items-center justify-center"
+          aria-label="Back to top"
         >
-          <button
-            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-[#030509] text-[12px] font-black tracking-wider shadow-2xl shadow-amber-500/40 active:scale-95 transition"
-          >
-            <ChevronUp className="w-4 h-4" /> BACK TO TOP
-          </button>
-        </motion.div>
+          <ChevronUp className="w-5 h-5" />
+        </motion.button>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Rebuilt `/kunj-bihari` around the **six things every investor actually evaluates**, in order. Each section is numbered so the reader knows where they are in the pitch:

```
① LOCATION       — satellite map + landmarks
② CONNECTIVITY   — NH-2 corridor + drive-time table
③ INFRASTRUCTURE — gated colony amenities
④ INDUSTRY       — real brand logos + marquee
⑤ SECURITY       — gated-boundary card
⑥ APPRECIATION   — growth stats + top-down pricing
```

### Specific feedback addressed

| Feedback | Fix |
|---|---|
| **"Blank gap a lot"** | Removed the 220vh sticky scrollytelling that was leaving 160vh of empty scroll below the Mathura entry. Replaced with a compact non-sticky NH-2 corridor diagram. |
| **"Remove 100 cr wherever"** | Stripped from hero badge, headline, copy. Hero badge now reads "A Fanbe Group Project". |
| **"Missed Durwasha Rishi Ashram"** | Added with 🕉️ icon to the landmarks list under LOCATION. |
| **"Registry instead of Clear Title"** | Trust badge renamed to "Immediate Registry" (FileCheck icon). Pricing card footer says "0% Interest · Immediate Registry with 35% payment". |
| **"Top-down pricing"** | Pricing card now shows the **largest** plot first (₹18.81L / 250 sq yd). The plot ladder below starts at 250 sq yd and descends to 50 sq yd. 100 sq yd marked POPULAR. |
| **"Industry with logo"** | Industry section now fetches real logos via `logo.clearbit.com/<domain>` — Maruti Suzuki, Reliance, Daikin, Havells, JK Tyre, Bharat Forge, Parle, Yazaki, UFlex. Shown in a 3×3 white-card grid AND a horizontally scrolling marquee strip below. Graceful fallback if a logo fails to load. |
| **"Investor understands location, connectivity, infrastructure, industry, security, appreciation"** | Exact six-section structure with numbered labels. |

### New Appreciation section
Four hand-picked growth drivers that justify the corridor thesis:
- **+22%** YoY land-price growth on NH-2 belt
- **+35%** YoY tourism rise in Braj Bhoomi (Mathura-Vrindavan)
- **5+** Active MNC manufacturing plants nearby
- **NH-2** Delhi-Agra national corridor frontage

Each in a gold-accented card with an icon.

### What's preserved
- Cinematic hero with letter-by-letter title, gold particles, parallax scroll
- 3D tilt on the pricing card
- Animated counters
- Pulsing crosshair on the satellite map
- Golden gem seal at the finale
- No phone/WhatsApp buttons — lead protection intact

## Test plan
- [ ] Scroll past the Mathura entry — confirm no large blank gap
- [ ] Check "₹100 Cr" appears nowhere on page
- [ ] Landmarks section includes Durwasha Rishi Ashram (🕉️)
- [ ] Trust badges show "Immediate Registry" (not "Clear Title")
- [ ] Pricing card shows ₹18.81L / 250 sq yd FIRST; plot ladder descends
- [ ] Industry logos actually render (Maruti, Reliance, etc.)
- [ ] Marquee scrolls smoothly with edge fades
- [ ] Appreciation cards animate in with the four growth stats

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_