### PR TITLE
fix(landing): kill continuous L→R shimmer on gold text + pricing card

### DIFF
--- a/src/pages/KunjBihariLanding.jsx
+++ b/src/pages/KunjBihariLanding.jsx
@@ -189,13 +189,10 @@ const KunjBihariLanding = () => {
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
         <style>{`
           @keyframes pulseRing { 0% { transform: scale(0.7); opacity: 0.9; } 100% { transform: scale(2.4); opacity: 0; } }
-          @keyframes shine { 0% { transform: translateX(-150%); } 60%, 100% { transform: translateX(150%); } }
           .gold-text {
-            background: linear-gradient(135deg, #FCD34D 0%, #F59E0B 35%, #FCD34D 50%, #F59E0B 65%, #FCD34D 100%);
-            background-size: 200% 200%;
+            background: linear-gradient(135deg, #FCD34D 0%, #F59E0B 50%, #FCD34D 100%);
             -webkit-background-clip: text; background-clip: text;
             -webkit-text-fill-color: transparent;
-            animation: shine 5s ease-in-out infinite;
           }
         `}</style>
       </Helmet>
@@ -602,13 +599,6 @@ const KunjBihariLanding = () => {
           <div className="relative rounded-[2rem] overflow-hidden shadow-2xl shadow-amber-500/30">
             <div className="absolute inset-0 bg-gradient-to-br from-amber-400 via-orange-500 to-amber-600" />
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.25),transparent_55%)]" />
-            <span
-              className="absolute -inset-px opacity-50 pointer-events-none"
-              style={{
-                background: 'linear-gradient(120deg, transparent 30%, rgba(255,255,255,0.4) 50%, transparent 70%)',
-                backgroundSize: '200% 100%', animation: 'shine 4s infinite',
-              }}
-            />
             <div className="relative p-6 text-[#030509]">
               <p className="text-[11px] font-bold tracking-[0.25em] uppercase opacity-70 mb-2">Now at corridor entry price</p>
 


### PR DESCRIPTION
## Summary

The "left → right" you were still seeing in your screen recording was two **continuous CSS keyframe shimmer animations** that I missed in previous passes:

1. **`.gold-text` class** had `animation: shine 5s ease-in-out infinite` driving `background-position` on every gold-colored heading (Shree Kunj Bihari, spot, NH-2, forever home, global manufacturers, keep climbing here, Your legacy, A Fanbe Group Project). The gold gradient slid horizontally across each of them, forever.
2. **Pricing card** had a translucent `<span>` overlay with `animation: shine 4s infinite` doing a `translateX(-150%) → translateX(150%)` sweep behind the discount price card.

### Change
- Stripped the `shine` animation from `.gold-text` — gold text now uses a static linear gradient
- Removed the shine-sweep `<span>` from the pricing card
- Deleted the `@keyframes shine` rule (no longer referenced)

### What's left
Only `pulseRing` infinite animations remain — those expand radially (outward) on the map crosshair, KOSI pin, and finale gem. Not horizontal motion.

## Test plan
- [ ] Open `/kunj-bihari` and watch every gold heading — no shimmer moving across them
- [ ] Scroll into the pricing card — no horizontal sweep behind it
- [ ] Map crosshair / KOSI pin / finale gem still pulse outward (radial)
- [ ] Everything else static

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_