### PR TITLE
fix(landing): map embed centers on actual Enclave by name, not fudged coords

### DIFF
--- a/src/pages/KunjBihariLanding.jsx
+++ b/src/pages/KunjBihariLanding.jsx
@@ -10,11 +10,12 @@ import {
 
 // ────────────────────────────────────────────────────────────────────────────
 const HERO = 'https://mfgjzkaabyltscgrkhdz.supabase.co/storage/v1/object/public/project-images/projects/shree-kunj-bihari/hero.jpg';
-const LAT = 27.7910;
-const LNG = 77.4385;
+// Place-name search — Google finds the actual location instead of us
+// guessing coordinates that don't match the real plot.
+const PLACE_QUERY = encodeURIComponent('Shree Kunj Bihari Enclave, Kosi Kalan, Mathura');
 const MAPS_LINK = 'https://maps.app.goo.gl/AdZxBk4tLRGceHAn8';
-const SATELLITE_EMBED = `https://maps.google.com/maps?q=${LAT},${LNG}&t=k&z=16&ie=UTF8&iwloc=&output=embed`;
-const HYBRID_EMBED    = `https://maps.google.com/maps?q=${LAT},${LNG}&t=h&z=15&ie=UTF8&iwloc=&output=embed`;
+const SATELLITE_EMBED = `https://maps.google.com/maps?q=${PLACE_QUERY}&t=k&z=16&ie=UTF8&iwloc=&output=embed`;
+const HYBRID_EMBED    = `https://maps.google.com/maps?q=${PLACE_QUERY}&t=h&z=15&ie=UTF8&iwloc=&output=embed`;
 
 const CORRIDOR = [
   { name: 'Delhi NCR',  km: '110 km', drive: '90 min', side: 'left'  },
@@ -311,7 +312,7 @@ const KunjBihariLanding = () => {
           </div>
           <div className="absolute top-3 right-3 z-10 px-2.5 py-1.5 rounded-full bg-black/70 backdrop-blur-md border border-emerald-400/30 flex items-center gap-1.5">
             <div className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
-            <span className="text-[9px] font-mono font-bold text-emerald-300 tracking-wider">27.79°N 77.44°E</span>
+            <span className="text-[9px] font-mono font-bold text-emerald-300 tracking-wider">KOSI · NH-2</span>
           </div>
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 pointer-events-none">
             <div className="relative w-16 h-16">


### PR DESCRIPTION
## Summary

You reported the satellite view on `/kunj-bihari` was showing a different spot than the real location at `https://maps.app.goo.gl/AdZxBk4tLRGceHAn8`.

### Root cause
The previous embed hardcoded `LAT=27.7910, LNG=77.4385` — coordinates I guessed for Kosi Kalan, not the actual plot. (I couldn't resolve your short link from the sandbox — Google returns 403 to outbound requests for `maps.app.goo.gl`.)

### Fix
Switched the embed query from raw coordinates to a **place-name search**:

```
q=Shree+Kunj+Bihari+Enclave%2C+Kosi+Kalan%2C+Mathura
```

Google's own search resolves to the proper place index entry, which should match what investors see when they tap the goo.gl link. The "Open in Maps ↗" button below the map still points at the canonical short URL.

Also removed the now-misleading `27.79°N 77.44°E` chip from the corner of the map — replaced with `KOSI · NH-2` so we don't display numbers that aren't actually driving the embed.

### If this still doesn't match
The place-name approach depends on Google having indexed the Enclave. If after merging the map still shows the wrong spot, share the exact `lat,lng` you see in the URL bar when you open the goo.gl link in a desktop browser, and I'll hardcode it.

## Test plan
- [ ] Open `/kunj-bihari` and scroll to the satellite section
- [ ] Confirm the pulsing crosshair is over the actual plot (cross-check with the goo.gl link)
- [ ] Try the Labels / Satellite toggle — both center on the same place
- [ ] "Open in Maps ↗" deep link still works

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_