### PR TITLE
feat(landing): kill WhatsApp bubble + premium scroll experience

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -303,6 +303,10 @@ function App() {
   // are working their lead list.
   const { pathname } = useLocation();
   const isCRM = pathname.startsWith('/crm');
+  // Telecaller-shared landing pages must NOT show the head-office WhatsApp
+  // bubble — if the investor taps it the lead routes to admin and gets
+  // snatched from the rep who shared the link.
+  const isLanding = pathname === '/kunj-bihari';
   return (
     <>
       <ScrollToTop />
@@ -311,8 +315,8 @@ function App() {
         isOpen={showSiteVisitModal}
         onClose={() => setShowSiteVisitModal(false)}
       />
-      <FloatingWhatsAppButton />
-      {!isCRM && <SocialProofToast />}
+      {!isLanding && <FloatingWhatsAppButton />}
+      {!isCRM && !isLanding && <SocialProofToast />}
       <Toaster />
     </>
   );

--- a/src/pages/KunjBihariLanding.jsx
+++ b/src/pages/KunjBihariLanding.jsx
@@ -159,6 +159,17 @@ const SectionLabel = ({ children }) => (
   <p className="text-amber-400 text-[11px] font-bold tracking-[0.3em] uppercase mb-3">{children}</p>
 );
 
+// Cinematic divider between sections — luxury-brochure detail
+const Divider = ({ idx, total = 6 }) => (
+  <div className="px-5 py-8 max-w-md mx-auto flex items-center gap-3 opacity-60">
+    <div className="flex-1 h-px bg-gradient-to-r from-transparent via-amber-500/40 to-transparent" />
+    <span className="text-[10px] font-bold tracking-[0.3em] text-amber-400">
+      {String(idx).padStart(2,'0')} / {String(total).padStart(2,'0')}
+    </span>
+    <div className="flex-1 h-px bg-gradient-to-r from-transparent via-amber-500/40 to-transparent" />
+  </div>
+);
+
 // ────────────────────────────────────────────────────────────────────────────
 
 const KunjBihariLanding = () => {
@@ -169,12 +180,27 @@ const KunjBihariLanding = () => {
   const heroOpac    = useTransform(heroProg, [0, 0.7, 1], [1, 0.6, 0]);
   const heroTitleY  = useTransform(heroProg, [0, 1], [0, -40]);
 
+  // Page-level scroll progress drives the top progress rail + section beacons
+  const { scrollYProgress: pageProg } = useScroll();
+  const pageProgPct = useSpring(pageProg, { stiffness: 80, damping: 22, mass: 0.5 });
+
   const [mapType, setMapType] = useState('satellite');
   const mapSrc = mapType === 'satellite' ? SATELLITE_EMBED : HYBRID_EMBED;
 
   const [showTopBtn, setShowTopBtn] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
   useEffect(() => {
-    const onScroll = () => setShowTopBtn(window.scrollY > 600);
+    const onScroll = () => {
+      setShowTopBtn(window.scrollY > 600);
+      // section beacons follow scroll percentage of the document
+      const sections = document.querySelectorAll('[data-section]');
+      let i = 0;
+      sections.forEach((el, k) => {
+        const t = el.getBoundingClientRect().top;
+        if (t < window.innerHeight * 0.4) i = k;
+      });
+      setActiveIdx(i);
+    };
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
@@ -197,6 +223,25 @@ const KunjBihariLanding = () => {
           }
         `}</style>
       </Helmet>
+
+      {/* Top gold scroll-progress rail — luxury micro-detail */}
+      <motion.div
+        style={{ scaleX: pageProgPct, transformOrigin: '0% 50%' }}
+        className="fixed top-0 left-0 right-0 h-[2px] z-[60] bg-gradient-to-r from-amber-300 via-amber-500 to-amber-300 shadow-[0_0_12px_rgba(245,158,11,0.6)] pointer-events-none"
+      />
+
+      {/* Right-edge section beacons — investors feel the page is a journey */}
+      <div className="fixed right-3 top-1/2 -translate-y-1/2 z-50 hidden sm:flex flex-col gap-3 pointer-events-none">
+        {['Location','Connectivity','Infrastructure','Industry','Security','Appreciation'].map((s, i) => (
+          <div key={s} className="flex items-center gap-2 transition-all duration-500"
+               style={{ opacity: activeIdx === i + 1 ? 1 : 0.35 }}>
+            <span className="text-[9px] font-bold tracking-widest text-amber-300 uppercase whitespace-nowrap">
+              {activeIdx === i + 1 ? s : ''}
+            </span>
+            <div className={`w-2 h-2 rounded-full transition-all duration-500 ${activeIdx === i + 1 ? 'bg-amber-400 shadow-[0_0_10px_rgba(245,158,11,0.8)] scale-150' : 'bg-white/30'}`} />
+          </div>
+        ))}
+      </div>
 
       {/* ════════ HERO ════════ */}
       <section ref={heroRef} className="relative min-h-[100svh] flex flex-col items-center justify-center text-center px-5 overflow-hidden">
@@ -285,7 +330,7 @@ const KunjBihariLanding = () => {
       {/* ════════════════════════════════════════════════════════════════════ */}
       {/* ① LOCATION                                                            */}
       {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 pt-24 pb-10 max-w-md mx-auto">
+      <section data-section="1" className="px-5 pt-24 pb-10 max-w-md mx-auto">
         <SectionLabel>① Location</SectionLabel>
         <h2 className="text-3xl font-black leading-tight mb-2">
           The exact <span className="gold-text">spot</span>
@@ -374,7 +419,9 @@ const KunjBihariLanding = () => {
       {/* ════════════════════════════════════════════════════════════════════ */}
       {/* ② CONNECTIVITY                                                       */}
       {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 pt-16 pb-10 max-w-md mx-auto">
+      <Divider idx={1} />
+
+      <section data-section="2" className="px-5 pt-16 pb-10 max-w-md mx-auto">
         <SectionLabel>② Connectivity</SectionLabel>
         <h2 className="text-3xl font-black leading-tight mb-2">
           On the spine of <span className="gold-text">NH-2</span>
@@ -463,7 +510,9 @@ const KunjBihariLanding = () => {
       {/* ════════════════════════════════════════════════════════════════════ */}
       {/* ③ INFRASTRUCTURE                                                     */}
       {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 pt-16 pb-10 max-w-md mx-auto">
+      <Divider idx={2} />
+
+      <section data-section="3" className="px-5 pt-16 pb-10 max-w-md mx-auto">
         <SectionLabel>③ Infrastructure</SectionLabel>
         <h2 className="text-3xl font-black leading-tight mb-2">
           Built like a <span className="gold-text">forever home</span>
@@ -495,7 +544,9 @@ const KunjBihariLanding = () => {
       {/* ════════════════════════════════════════════════════════════════════ */}
       {/* ④ INDUSTRY — with real logos                                         */}
       {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="pt-16 pb-10">
+      <Divider idx={3} />
+
+      <section data-section="4" className="pt-16 pb-10">
         <div className="px-5 max-w-md mx-auto mb-6">
           <SectionLabel>④ Industry</SectionLabel>
           <h2 className="text-3xl font-black leading-tight mb-2">
@@ -537,7 +588,9 @@ const KunjBihariLanding = () => {
       {/* ════════════════════════════════════════════════════════════════════ */}
       {/* ⑤ SECURITY                                                            */}
       {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 pt-16 pb-10 max-w-md mx-auto">
+      <Divider idx={4} />
+
+      <section data-section="5" className="px-5 pt-16 pb-10 max-w-md mx-auto">
         <SectionLabel>⑤ Security</SectionLabel>
         <h2 className="text-3xl font-black leading-tight mb-6">
           A community you can <span className="text-blue-400">leave at the gate</span>
@@ -567,7 +620,9 @@ const KunjBihariLanding = () => {
       {/* ════════════════════════════════════════════════════════════════════ */}
       {/* ⑥ APPRECIATION                                                       */}
       {/* ════════════════════════════════════════════════════════════════════ */}
-      <section className="px-5 pt-16 pb-10 max-w-md mx-auto">
+      <Divider idx={5} />
+
+      <section data-section="6" className="px-5 pt-16 pb-10 max-w-md mx-auto">
         <SectionLabel>⑥ Appreciation</SectionLabel>
         <h2 className="text-3xl font-black leading-tight mb-2">
           Why prices <span className="gold-text">keep climbing here</span>


### PR DESCRIPTION
## Summary

Two asks, one PR.

### 1. Killed the floating WhatsApp bubble on `/kunj-bihari`
The green "Chat with us" icon (and the auto-firing "X just booked!" Social Proof toast) were both rendering from `App.jsx` on top of the landing. Both routed leads to the head-office contact path — i.e., **investor taps it → lead snatched from the telecaller who shared the link.**

Gated both behind `isLanding`:

```js
const isLanding = pathname === '/kunj-bihari';
// ...
{!isLanding && <FloatingWhatsAppButton />}
{!isCRM && !isLanding && <SocialProofToast />}
```

### 2. Premium scroll experience
Three additions that make scrolling feel like turning the pages of a developer's brochure:

**Top gold progress rail (fixed):** 2px gradient bar pinned to the top edge that fills 0 → 100% as the investor scrolls. Uses `useScroll() + useSpring` (stiffness 80, damping 22) for a soft inertial feel + an amber drop-shadow glow. Looks like the spine of a luxury catalog filling in as they read.

**Right-edge section beacons (fixed):** Six dots stacked vertically; the active one pulses amber with a `10px` glow and scales 1.5×. The section name fades in next to the active dot. Tracks `data-section` attributes (1-6) via `getBoundingClientRect` on scroll. Investor always knows where they are in the pitch. Hidden on small phones (`sm:flex`) to not crowd content.

**Chapter dividers between sections:** Reusable `Divider` component renders a thin amber gradient line on each side of a `"01 / 06"` style marker. Inserted between each of the six numbered sections.

### Why this works for the "₹100Cr feeling" you asked for
- Investors visiting from a telecaller's WhatsApp message get a curated, narrated experience
- The progress rail signals "this is structured content" → premium positioning
- The chapter markers ("01 / 06") imply intentional pacing — not a generic landing page
- Side beacons let them mentally locate themselves in the pitch without scrolling back

All scroll-driven UI is calm and natural — no sequential reveals, no horizontal shimmers (per your earlier feedback).

## Test plan
- [ ] Open `/kunj-bihari` — no green WhatsApp bubble in the bottom-right
- [ ] No "X just booked!" social proof popup
- [ ] Scroll down — top edge gold bar fills smoothly with a soft delay
- [ ] On tablet/desktop, right-edge beacon highlights the active section as you scroll past Location → Connectivity → Infrastructure → Industry → Security → Appreciation
- [ ] Between each numbered section, see a "01 / 06" style chapter divider line

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_