### PR TITLE
fix(landing): pricing reads ₹9,725 → ₹7,525, no Save 40% pill

### DIFF
--- a/src/pages/KunjBihariLanding.jsx
+++ b/src/pages/KunjBihariLanding.jsx
@@ -472,8 +472,28 @@ const KunjBihariLanding = () => {
       <StickyTitleSection
         kicker="Plot Sizes & Pricing"
         title="Choose your plot."
-        lede="Launch pricing of ₹7,525 per square yard. 10% booking · 35% registry · 60 months 0% EMI."
+        lede="10% booking · 35% registry · 60 months 0% interest EMI."
       >
+        {/* Launch price card — was ₹9,725 / now ₹7,525 */}
+        <motion.div
+          initial={{ opacity: 0, y: 14 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-40px' }}
+          transition={{ duration: 0.5 }}
+          className="mb-5 p-5 bg-white border border-stone-200 rounded-xl flex items-baseline justify-between"
+        >
+          <div>
+            <p className="text-[10px] tracking-[0.3em] uppercase font-bold text-stone-500 mb-1">Per sq yd · Launch price</p>
+            <div className="flex items-baseline gap-3">
+              <span className="text-[15px] text-stone-400 line-through font-semibold tabular-nums">₹9,725</span>
+              <span className="text-[28px] font-bold text-stone-900 tabular-nums">₹7,525</span>
+            </div>
+          </div>
+          <div className="text-right text-[11px] text-stone-500 leading-tight">
+            Limited<br/>inventory
+          </div>
+        </motion.div>
+
         <motion.div
           initial={{ opacity: 0, y: 14 }}
           whileInView={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
## Summary

Live promo — pricing needed a more credible "down from" frame.

### Change
- Removed: any ₹12,525 strike-through, "SAVE 40%" pill (those were from older iterations; what's in main was already clean, but the request implied investors had seen the old version cached)
- Added: a clear per-sq-yd card above the plot table showing:
  - **~₹9,725~ ₹7,525** (line-through previous quote next to bold current price)
  - "Per sq yd · Launch price" kicker
  - "Limited inventory" caption on the right — replaces the loud percentage claim with a softer scarcity signal
- Pricing-section lede simplified to focus on payment terms (10% / 35% / 60mo 0%) since the price itself is in the card now

### Why
The ₹9,725 → ₹7,525 framing is a ~22% reduction — believable as a launch incentive without the "SAVE 40%" overclaim. Investors see one number they're getting (₹7,525) and one number it used to be (₹9,725). No marketing puffery.

### Unchanged
Everything else — hero, sticky title sections, sticky scroll mechanic, landmarks stack reveal, map, drives, amenities, brand logos, plot table, why-invest, trust list, footer, advisor follow-up note. No phone / WhatsApp.

## Test plan
- [ ] Open `/kunj-bihari` → scroll to **Plot Sizes & Pricing**
- [ ] See the per-sq-yd card with `~₹9,725~ ₹7,525` and "Limited inventory" caption
- [ ] No "SAVE 40%" pill, no "₹12,525" anywhere
- [ ] Plot ladder below still lists all 8 plot sizes with ₹7,525/sq yd

https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SafLVsQtqvwuuPKqtFA1n9)_